### PR TITLE
Local/Docker Kafka support, lesson04 materialized views, and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # Educational project - keep it simple and focused
 
 
+# AI assistant artifacts (not committed)
+.junie/
+.kiro/
+.claude/
+
 # IDE configuration files
 .idea/
 .vscode/

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,218 @@
+# Migration Guide: Flink 2.0 Source API
+
+## Overview
+
+This guide explains the migration from the deprecated `SourceFunction` API to the new FLIP-27 `Source` API in Apache Flink 2.0.
+
+## What Changed?
+
+### Deprecated API (Flink 1.x)
+```java
+import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
+
+public class OrderDataGenerator implements SourceFunction<Order> {
+    private volatile boolean running = true;
+    
+    @Override
+    public void run(SourceContext<Order> ctx) throws Exception {
+        while (running) {
+            Order order = generateOrder();
+            ctx.collect(order);
+            Thread.sleep(2000);
+        }
+    }
+    
+    @Override
+    public void cancel() {
+        running = false;
+    }
+}
+
+// Usage
+DataStream<Order> orders = env.addSource(new OrderDataGenerator());
+```
+
+### New API (Flink 2.0)
+```java
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
+
+public class OrderDataGenerator {
+    public static Source<Order, ?, ?> createSource(long numberOfOrders) {
+        GeneratorFunction<Long, Order> generatorFunction = index -> {
+            // Generate order based on index
+            return new Order(...);
+        };
+        
+        return new DataGeneratorSource<>(
+            generatorFunction,
+            numberOfOrders,
+            TypeInformation.of(Order.class)
+        );
+    }
+}
+
+// Usage
+DataStream<Order> orders = env.fromSource(
+    OrderDataGenerator.createUnboundedSource(),
+    WatermarkStrategy.noWatermarks(),
+    "Order Source"
+);
+```
+
+## Key Differences
+
+### 1. **Static Factory Methods Instead of Instantiation**
+- **Old**: `new OrderDataGenerator()`
+- **New**: `OrderDataGenerator.createSource(...)` or `OrderDataGenerator.createUnboundedSource()`
+
+### 2. **Using `fromSource()` Instead of `addSource()`**
+- **Old**: `env.addSource(sourceFunction)`
+- **New**: `env.fromSource(source, watermarkStrategy, sourceName)`
+
+### 3. **Index-Based Generation**
+The new `GeneratorFunction` receives a `Long` index parameter, making it easier to generate deterministic data:
+```java
+GeneratorFunction<Long, Order> generatorFunction = index -> {
+    String orderId = "order_" + String.format("%05d", index);
+    // ... generate order
+};
+```
+
+### 4. **Built-in Parallelism Support**
+The new API automatically handles parallelism - each parallel instance gets a different range of indices.
+
+### 5. **No Manual Thread Management**
+- **Old**: Required `Thread.sleep()` and `volatile boolean running`
+- **New**: No manual threading - the framework handles timing and cancellation
+
+## Migration Steps for OrderDataGenerator
+
+### Step 1: Update Imports
+```java
+// Remove
+import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
+
+// Add
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+```
+
+### Step 2: Convert to Static Factory Pattern
+```java
+public class OrderDataGenerator {
+    // Static factory methods
+    public static Source<Order, ?, ?> createSource(long numberOfOrders) { ... }
+    public static Source<Order, ?, ?> createUnboundedSource() { ... }
+    public static Source<Order, ?, ?> createBoundedSource(long numberOfOrders) { ... }
+}
+```
+
+### Step 3: Implement GeneratorFunction
+```java
+private static class OrderGeneratorFunction implements GeneratorFunction<Long, Order> {
+    private static final long serialVersionUID = 1L;
+    private transient Random random;
+
+    @Override
+    public Order map(Long index) throws Exception {
+        if (random == null) {
+            random = new Random();
+        }
+        // Generate order using index
+        return new Order(...);
+    }
+}
+```
+
+### Step 4: Update Usage in Your Code
+```java
+// Old way
+DataStream<Order> orders = env.addSource(new OrderDataGenerator());
+
+// New way
+DataStream<Order> orders = env.fromSource(
+    OrderDataGenerator.createUnboundedSource(),
+    WatermarkStrategy.noWatermarks(),
+    "Order Generator"
+);
+```
+
+## Benefits of the New API
+
+1. **Better Performance**: The new API is more efficient and scalable
+2. **Unified Batch & Streaming**: Same API works for both bounded and unbounded sources
+3. **Built-in Checkpointing**: Better integration with Flink's checkpointing mechanism
+4. **Cleaner Code**: No manual thread management or cancellation logic
+5. **Type Safety**: Better type inference and compile-time checking
+
+## Available Factory Methods
+
+### `createSource(long numberOfOrders)`
+Creates a source that generates a specific number of orders.
+
+### `createUnboundedSource()`
+Creates a source that generates orders continuously (Long.MAX_VALUE).
+
+### `createBoundedSource(long numberOfOrders)`
+Creates a bounded source with a specific number of orders.
+
+## Example: Complete Migration
+
+### Before (Flink 1.x)
+```java
+public class OrderProcessingJob {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        
+        DataStream<Order> orders = env.addSource(new OrderDataGenerator())
+            .name("Order Source");
+        
+        // Process orders...
+        
+        env.execute("Order Processing");
+    }
+}
+```
+
+### After (Flink 2.0)
+```java
+public class OrderProcessingJob {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        
+        DataStream<Order> orders = env.fromSource(
+            OrderDataGenerator.createUnboundedSource(),
+            WatermarkStrategy.noWatermarks(),
+            "Order Source"
+        );
+        
+        // Process orders...
+        
+        env.execute("Order Processing");
+    }
+}
+```
+
+## Troubleshooting
+
+### Issue: "Cannot find symbol: SourceFunction"
+**Solution**: You're using the old API. Update imports and use the new `Source` API.
+
+### Issue: "addSource is deprecated"
+**Solution**: Replace `env.addSource()` with `env.fromSource()` and provide a `WatermarkStrategy`.
+
+### Issue: "DataGeneratorSource not found"
+**Solution**: Ensure you have the correct Flink dependencies in your `build.gradle.kts`:
+```kotlin
+implementation("org.apache.flink:flink-connector-datagen:$flinkVersion")
+```
+
+## Additional Resources
+
+- [FLIP-27: Refactor Source Interface](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface)
+- [Flink 2.0 DataStream API Documentation](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/sources/)
+- [DataGeneratorSource JavaDoc](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/connector/datagen/source/DataGeneratorSource.html)

--- a/WEBUI_QUICKSTART.md
+++ b/WEBUI_QUICKSTART.md
@@ -1,0 +1,123 @@
+# Flink Web UI - Quick Start
+
+## 🚀 Get Started in 3 Steps
+
+### 1. Run Any Lesson
+```bash
+./gradlew runLesson01
+```
+
+### 2. Open Your Browser
+Navigate to: **http://localhost:8081**
+
+### 3. Explore!
+- Click "Running Jobs" to see your pipeline
+- View the execution graph
+- Monitor metrics in real-time
+
+---
+
+## 📊 What You'll See
+
+### Execution Graph
+Visual representation of your data pipeline showing:
+- Source operators (where data comes from)
+- Transformation operators (map, filter, keyBy, etc.)
+- Sink operators (where data goes)
+
+### Real-Time Metrics
+- Records processed per second
+- Bytes sent/received
+- Backpressure indicators
+- Task status
+
+### Checkpoints
+- Checkpoint history
+- State size
+- Duration
+- Success/failure status
+
+---
+
+## 🎓 Educational Value
+
+### Lesson 1: DataStream API
+See how `flatMap`, `keyBy`, and `sum` connect together
+
+### Lesson 2: Kafka Integration
+Monitor Kafka source performance and throughput
+
+### Lesson 3: Order Processing
+Compare execution graphs of different processing patterns
+
+### Lessons 4 & 5: Table API/SQL
+Understand how SQL translates to DataStream operations
+
+---
+
+## 🛠️ Available Commands
+
+```bash
+# DataStream API basics
+./gradlew runLesson01
+
+# Kafka integration
+./gradlew runLesson02
+
+# Order processing jobs
+./gradlew runLesson03A  # Customer tracking
+./gradlew runLesson03B  # VIP detection
+./gradlew runLesson03C  # Frequency analysis
+./gradlew runLesson03D  # Category spending
+
+# Advanced topics
+./gradlew runLesson04   # Materialized views
+./gradlew runLesson05   # Table API & SQL
+```
+
+---
+
+## 🔍 Troubleshooting
+
+### Port Already in Use?
+```bash
+# Find what's using port 8081
+lsof -i :8081
+
+# Kill the process
+kill -9 <PID>
+```
+
+### Web UI Not Loading?
+1. Ensure the lesson is still running (don't stop it!)
+2. Try http://127.0.0.1:8081 instead
+3. Check firewall settings
+
+### No Jobs Visible?
+- Streaming jobs run continuously - keep the process running
+- Batch-like jobs (Lesson 1) may complete quickly
+- Check the "Completed Jobs" tab
+
+---
+
+## 📚 Learn More
+
+- **Detailed Guide**: [docs/WEB_UI_GUIDE.md](docs/WEB_UI_GUIDE.md)
+- **Implementation Details**: [docs/WEBUI_IMPLEMENTATION.md](docs/WEBUI_IMPLEMENTATION.md)
+- **Flink Documentation**: https://flink.apache.org/
+
+---
+
+## ✨ Pro Tips
+
+1. **Disable Operator Chaining**: Already done! Each step is visible separately
+2. **Parallelism = 1**: Makes it easier to follow data flow
+3. **Flame Graphs**: Enabled by default for performance profiling
+4. **Multiple Jobs**: Run different lessons to compare execution patterns
+5. **Checkpoints**: Watch state grow as your job processes data
+
+---
+
+**Happy Learning! 🎉**
+
+For questions or issues, check the documentation or open an issue on GitHub.

--- a/docs/WEBUI_IMPLEMENTATION.md
+++ b/docs/WEBUI_IMPLEMENTATION.md
@@ -1,0 +1,182 @@
+# Flink Web UI Implementation Summary
+
+## Overview
+
+This document summarizes the implementation of Flink Web UI support for all Java-based lessons in the Flink Demo Suite.
+
+## Changes Made
+
+### 1. New Utility Class: `FlinkEnvironmentConfig`
+
+**Location**: `shared/utils/FlinkEnvironmentConfig.java`
+
+**Purpose**: Centralized configuration for creating Flink execution environments with Web UI enabled.
+
+**Key Methods**:
+- `createEnvironmentWithUI()`: Creates a StreamExecutionEnvironment with Web UI enabled on port 8081
+- `createLocalEnvironment()`: Creates a standard local environment without Web UI (for comparison)
+- `printWebUIInstructions()`: Displays formatted instructions for accessing the Web UI
+
+**Configuration**:
+- REST API enabled on port 8081
+- Flame graphs enabled for performance profiling
+- Parallelism set to 1 for educational clarity
+- Operator chaining disabled to visualize individual steps
+- Checkpointing enabled (60-second intervals)
+
+### 2. Updated Lesson Files
+
+All lesson files now use `FlinkEnvironmentConfig.createEnvironmentWithUI()` instead of creating environments manually:
+
+#### Lesson 1: StreamingWordCount.java
+- Replaced manual environment creation with `FlinkEnvironmentConfig.createEnvironmentWithUI()`
+- Added Web UI instructions display
+- Removed redundant configuration code
+
+#### Lesson 2: KafkaConsumerExample.java
+- Updated to use centralized environment configuration
+- Added Web UI instructions
+- Maintains all Kafka integration functionality
+
+#### Lesson 3: BaseOrderProcessingJob.java
+- Updated base class to use `FlinkEnvironmentConfig`
+- All four order processing jobs (3A-3D) inherit Web UI support
+- Added Web UI instructions to job header
+
+#### Lesson 4: MaterializedViewExample.java
+- Updated conceptual lesson to use Web UI configuration
+- Ready for when Table API dependencies become available
+
+#### Lesson 5: TableAPIExample.java
+- Updated conceptual lesson to use Web UI configuration
+- Ready for when Table API dependencies become available
+
+### 3. Documentation
+
+#### New: `docs/WEB_UI_GUIDE.md`
+Comprehensive guide covering:
+- How to access the Web UI
+- What you can see in the UI
+- Educational benefits for each lesson
+- Tips and troubleshooting
+- Comparison of local vs Docker execution
+
+#### Updated: `.kiro/steering/tech.md`
+- Added prominent section about Web UI support
+- Linked to detailed guide
+- Highlighted automatic enablement for all lessons
+
+### 4. Testing
+
+#### New: `test-webui.sh`
+Automated test script that:
+- Builds the project
+- Starts Lesson 1 in background
+- Waits for Web UI availability
+- Tests multiple endpoints
+- Provides cleanup on exit
+
+## Technical Details
+
+### Web UI Configuration
+
+The Web UI is enabled using Flink's `createLocalEnvironmentWithWebUI()` method with custom configuration:
+
+```java
+Configuration config = new Configuration();
+config.set(RestOptions.BIND_PORT, "8081");
+config.set(RestOptions.ENABLE_FLAMEGRAPH, true);
+StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(config);
+```
+
+### Port Configuration
+
+- **Port 8081**: Flink Web UI REST API
+- **Automatic**: No manual setup required
+- **Conflict Resolution**: If port is in use, instructions provided in guide
+
+### Educational Benefits
+
+1. **Visual Learning**: Students can see their pipeline as a directed graph
+2. **Real-time Monitoring**: Observe data flowing through operators
+3. **Performance Understanding**: Track metrics, backpressure, and throughput
+4. **Debugging**: Identify bottlenecks and issues visually
+5. **State Management**: Monitor checkpoint sizes and frequencies
+
+## Usage
+
+### Running Lessons with Web UI
+
+All existing Gradle tasks now automatically enable Web UI:
+
+```bash
+./gradlew runLesson01  # DataStream API
+./gradlew runLesson02  # Kafka Integration
+./gradlew runLesson03A # Customer Order Tracking
+./gradlew runLesson03B # VIP Customer Detection
+./gradlew runLesson03C # Order Frequency Analysis
+./gradlew runLesson03D # Category Spending Analysis
+./gradlew runLesson04  # Materialized Views
+./gradlew runLesson05  # Table API and SQL
+```
+
+### Accessing the Web UI
+
+1. Run any lesson using the commands above
+2. Open browser to http://localhost:8081
+3. Explore the running job, execution graph, and metrics
+
+### Testing the Implementation
+
+```bash
+./test-webui.sh
+```
+
+This will:
+- Build the project
+- Start a lesson
+- Verify Web UI is accessible
+- Test multiple endpoints
+- Show live logs
+
+## Backward Compatibility
+
+- ✅ All existing functionality preserved
+- ✅ No breaking changes to lesson code
+- ✅ Gradle tasks work exactly as before
+- ✅ Docker cluster execution still supported
+- ✅ Can still run without Web UI if needed (using `createLocalEnvironment()`)
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+1. **Custom Port Configuration**: Allow users to specify different ports via environment variables
+2. **Metrics Dashboard**: Create custom dashboards for specific lessons
+3. **Automated Screenshots**: Capture execution graphs for documentation
+4. **Performance Benchmarks**: Use Web UI metrics for performance comparisons
+5. **Interactive Tutorials**: Guide users through Web UI features step-by-step
+
+## Dependencies
+
+No new dependencies were added. The implementation uses existing Flink libraries:
+- `org.apache.flink:flink-streaming-java:2.0.0`
+- `org.apache.flink:flink-clients:2.0.0`
+
+## Testing Checklist
+
+- [x] Build succeeds without errors
+- [x] Lesson 1 runs with Web UI enabled
+- [x] Lesson 2 runs with Web UI enabled
+- [x] Lesson 3 jobs run with Web UI enabled
+- [x] Lesson 4 runs with Web UI enabled
+- [x] Lesson 5 runs with Web UI enabled
+- [x] Web UI accessible at http://localhost:8081
+- [x] Execution graphs visible in UI
+- [x] Metrics updating in real-time
+- [x] Documentation complete and accurate
+- [x] No breaking changes to existing code
+
+## Conclusion
+
+The Flink Web UI has been successfully integrated into all Java-based lessons, providing students with a powerful visual tool for understanding stream processing concepts. The implementation is clean, maintainable, and enhances the educational value of the demo suite without adding complexity or breaking existing functionality.

--- a/docs/WEBUI_IMPLEMENTATION.md
+++ b/docs/WEBUI_IMPLEMENTATION.md
@@ -160,8 +160,8 @@ Potential improvements for future iterations:
 ## Dependencies
 
 No new dependencies were added. The implementation uses existing Flink libraries:
-- `org.apache.flink:flink-streaming-java:2.0.0`
-- `org.apache.flink:flink-clients:2.0.0`
+- `org.apache.flink:flink-streaming-java:2.2.0`
+- `org.apache.flink:flink-clients:2.2.0`
 
 ## Testing Checklist
 

--- a/docs/WEBUI_IMPLEMENTATION.md
+++ b/docs/WEBUI_IMPLEMENTATION.md
@@ -8,7 +8,7 @@ This document summarizes the implementation of Flink Web UI support for all Java
 
 ### 1. New Utility Class: `FlinkEnvironmentConfig`
 
-**Location**: `shared/utils/FlinkEnvironmentConfig.java`
+**Location**: `src/main/java/utils/FlinkEnvironmentConfig.java` (package `utils`)
 
 **Purpose**: Centralized configuration for creating Flink execution environments with Web UI enabled.
 

--- a/docs/WEB_UI_GUIDE.md
+++ b/docs/WEB_UI_GUIDE.md
@@ -1,0 +1,179 @@
+# Flink Web UI Guide
+
+## Overview
+
+All Java-based lessons now support the Flink Web UI, allowing you to visualize and monitor your streaming pipelines in real-time. This is an essential tool for understanding how Flink processes data and debugging your applications.
+
+## Accessing the Web UI
+
+When you run any lesson, you'll see instructions like this:
+
+```
+╔════════════════════════════════════════════════════════════╗
+║           Flink Web UI Access Instructions                ║
+╠════════════════════════════════════════════════════════════╣
+║  Open your browser and navigate to:                       ║
+║  → http://localhost:8081                                   ║
+║                                                            ║
+║  In the Web UI you can:                                    ║
+║  • View the execution graph of your streaming pipeline     ║
+║  • Monitor job status and metrics in real-time             ║
+║  • Check task manager resources and performance            ║
+║  • View checkpoints and savepoints                         ║
+║  • Debug issues using logs and flame graphs                ║
+╚════════════════════════════════════════════════════════════╝
+```
+
+Simply open your browser and go to **http://localhost:8081**
+
+## What You Can See
+
+### 1. Job Overview
+- **Running Jobs**: See all currently executing Flink jobs
+- **Completed Jobs**: View history of finished jobs
+- **Job Status**: Monitor job health and execution state
+
+### 2. Execution Graph
+- **Visual Pipeline**: See your data flow as a directed graph
+- **Operators**: Each transformation step is visualized
+- **Parallelism**: Understand how tasks are distributed
+- **Operator Chaining**: See which operators are chained together (disabled in lessons for clarity)
+
+### 3. Metrics & Performance
+- **Records Processed**: Track throughput in real-time
+- **Backpressure**: Identify bottlenecks in your pipeline
+- **Latency**: Monitor processing delays
+- **Resource Usage**: CPU, memory, and network metrics
+
+### 4. Checkpoints
+- **Checkpoint History**: View all completed checkpoints
+- **State Size**: Monitor how much state your job maintains
+- **Duration**: Track checkpoint completion times
+- **Failures**: Identify checkpoint issues
+
+### 5. Task Managers
+- **Available Slots**: See task execution capacity
+- **Resource Allocation**: Monitor CPU and memory usage
+- **Task Distribution**: Understand how work is distributed
+
+## Educational Benefits
+
+### For Lesson 1 (DataStream API)
+- See how `flatMap`, `keyBy`, and `sum` operators are connected
+- Understand data flow through the pipeline
+- Observe operator chaining (disabled for clarity)
+
+### For Lesson 2 (Kafka Integration)
+- Monitor Kafka source connector performance
+- Track records consumed from Kafka
+- View deserialization metrics
+
+### For Lesson 3 (Data Processing Patterns)
+- Compare execution graphs of different jobs
+- Understand windowing operations visually
+- Monitor state size for stateful operations
+
+### For Lessons 4 & 5 (Table API/SQL)
+- See how SQL queries are translated to DataStream operations
+- Understand query optimization
+- Monitor materialized view updates
+
+## Tips for Using the Web UI
+
+1. **Start Simple**: Begin with Lesson 1 to understand basic pipeline visualization
+2. **Operator Chaining**: Notice that chaining is disabled in lessons - this makes each step visible
+3. **Parallelism**: Set to 1 for clarity - increase it to see parallel execution
+4. **Refresh**: The UI updates automatically, but you can manually refresh for latest data
+5. **Flame Graphs**: Use flame graphs to identify performance hotspots (enabled by default)
+
+## Troubleshooting
+
+### Port Already in Use
+If port 8081 is already in use:
+```bash
+# Find the process using port 8081
+lsof -i :8081
+
+# Kill the process if needed
+kill -9 <PID>
+```
+
+### Web UI Not Loading
+1. Ensure your lesson is running (don't stop the Java process)
+2. Check that port 8081 is accessible
+3. Try accessing from `http://127.0.0.1:8081` instead
+
+### No Jobs Visible
+- The job only appears while the lesson is running
+- For streaming jobs, they run continuously until you stop them (Ctrl+C)
+- For batch-like jobs (Lesson 1), they may complete quickly
+
+## Running Lessons with Web UI
+
+All lesson run commands now automatically enable the Web UI:
+
+```bash
+# Lesson 1: DataStream API
+./gradlew runLesson01
+
+# Lesson 2: Kafka Integration
+./gradlew runLesson02
+
+# Lesson 3: Order Processing Jobs
+./gradlew runLesson03A  # Customer Order Tracking
+./gradlew runLesson03B  # VIP Customer Detection
+./gradlew runLesson03C  # Order Frequency Analysis
+./gradlew runLesson03D  # Category Spending Analysis
+
+# Lesson 4: Materialized Views
+./gradlew runLesson04
+
+# Lesson 5: Table API and SQL
+./gradlew runLesson05
+```
+
+## Docker Cluster vs Local Execution
+
+### Local Execution with Web UI (Current Setup)
+- ✅ Runs directly from your IDE or Gradle
+- ✅ Web UI at http://localhost:8081
+- ✅ Easy debugging with IDE breakpoints
+- ✅ Fast iteration and development
+- ✅ No Docker required
+
+### Docker Cluster Execution (Alternative)
+If you want to submit jobs to the Docker cluster instead:
+
+```bash
+# Start the Flink cluster
+docker-compose up -d
+
+# Build the shadow JAR
+./gradlew shadowJar
+
+# Submit to cluster
+docker exec flink-jobmanager flink run /opt/flink/usrlib/flink-demo.jar
+```
+
+The Docker cluster also provides a Web UI at http://localhost:8081
+
+## Next Steps
+
+1. **Run Lesson 1**: Start with the basics
+   ```bash
+   ./gradlew runLesson01
+   ```
+
+2. **Open Web UI**: Navigate to http://localhost:8081
+
+3. **Explore**: Click through the tabs and explore the execution graph
+
+4. **Experiment**: Modify lesson code and see how the graph changes
+
+5. **Monitor**: Watch metrics update in real-time as data flows through
+
+## Additional Resources
+
+- [Apache Flink Web UI Documentation](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/monitoring/web_ui/)
+- [Flink Metrics System](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/metrics/)
+- [Debugging Flink Applications](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/debugging/)

--- a/docs/java21-upgrade-guide.md
+++ b/docs/java21-upgrade-guide.md
@@ -1,0 +1,171 @@
+# Java 21 Upgrade Guide for Flink 101 Java Project
+
+## Overview
+
+This Flink 101 Java project has been successfully upgraded from Java 17 to Java 21 LTS. This guide documents the changes made and provides recommendations for leveraging Java 21 features.
+
+## Changes Made
+
+### 1. Build Configuration Updates
+
+- **build.gradle.kts**: Updated `sourceCompatibility` and `targetCompatibility` from `VERSION_17` to `VERSION_21`
+- **docker-compose.yml**: Updated Flink images from `flink:2.0.0-scala_2.12-java17` to `flink:2.0.0-scala_2.12-java21`
+- **GitHub Actions**: Updated CI workflow to use Java 21 exclusively
+
+### 2. Compatibility Verification
+
+✅ **Build Status**: All builds successful  
+✅ **Test Status**: All tests passing  
+✅ **Runtime Status**: All lessons execute correctly  
+✅ **Flink Compatibility**: Flink 2.0.0 fully supports Java 21  
+
+### 3. Deprecation Warnings
+
+The upgrade revealed some deprecation warnings related to `SourceFunction` in the data generators. These are Flink API evolution warnings, not Java 21 compatibility issues.
+
+## Java 21 Features You Can Leverage
+
+### 1. Pattern Matching for Switch (JEP 441)
+```java
+// Before (traditional switch)
+String processOrderStatus(OrderStatus status) {
+    switch (status) {
+        case PENDING:
+            return "Order is being processed";
+        case SHIPPED:
+            return "Order has been shipped";
+        case DELIVERED:
+            return "Order has been delivered";
+        default:
+            return "Unknown status";
+    }
+}
+
+// After (pattern matching switch - Java 21)
+String processOrderStatus(OrderStatus status) {
+    return switch (status) {
+        case PENDING -> "Order is being processed";
+        case SHIPPED -> "Order has been shipped";
+        case DELIVERED -> "Order has been delivered";
+    };
+}
+```
+
+### 2. Record Patterns (JEP 440)
+```java
+// Define a record for order data
+public record Order(String id, String customer, double amount, String category) {}
+
+// Use pattern matching to destructure records
+String analyzeOrder(Order order) {
+    return switch (order) {
+        case Order(var id, var customer, double amount, var category) 
+            when amount > 1000 -> "High-value order: " + id;
+        case Order(var id, var customer, double amount, "electronics") 
+            -> "Electronics order: " + id;
+        default -> "Regular order: " + order.id();
+    };
+}
+```
+
+### 3. String Templates (Preview in Java 21)
+```java
+// Note: This is a preview feature in Java 21, enable with --enable-preview
+String generateOrderSummary(String orderId, String customer, double amount) {
+    return STR."Order \{orderId} for customer \{customer} totaling $\{amount}";
+}
+```
+
+### 4. Virtual Threads (JEP 444)
+For high-throughput streaming applications:
+```java
+// Create virtual thread executor for parallel processing
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    // Process multiple streams concurrently
+    executor.submit(() -> processOrderStream());
+    executor.submit(() -> processPaymentStream());
+    executor.submit(() -> processInventoryStream());
+}
+```
+
+### 5. Sequenced Collections (JEP 431)
+Improved collection operations:
+```java
+// Better control over order in collections
+List<Order> orders = new ArrayList<>();
+Order firstOrder = orders.getFirst();  // Instead of get(0)
+Order lastOrder = orders.getLast();    // Instead of get(size()-1)
+orders.addFirst(urgentOrder);          // Instead of add(0, order)
+```
+
+## Recommended Modernization Steps
+
+### 1. Update Data Models to Records
+Consider converting simple POJOs to records for immutability and conciseness:
+```java
+// Current Order class could become:
+public record Order(
+    String orderId,
+    String customerId,
+    String productId,
+    int quantity,
+    double price,
+    Instant timestamp,
+    String category
+) {}
+```
+
+### 2. Leverage Pattern Matching
+Update switch statements in your Flink jobs to use pattern matching for cleaner code.
+
+### 3. Use Text Blocks for SQL Queries
+If you add SQL queries for Table API examples:
+```java
+String query = """
+    SELECT customer_id,
+           SUM(amount) as total_spent,
+           COUNT(*) as order_count
+    FROM orders
+    WHERE timestamp > INTERVAL '1' HOUR
+    GROUP BY customer_id
+    """;
+```
+
+### 4. Consider Virtual Threads for I/O
+For Kafka producers/consumers or external API calls, virtual threads can improve throughput.
+
+## Performance Benefits
+
+- **Improved G1GC**: Better performance for large heap applications
+- **Virtual Threads**: Better scalability for I/O-bound operations
+- **Pattern Matching**: More efficient bytecode generation
+- **General Performance**: Various JVM improvements and optimizations
+
+## Migration Notes
+
+1. **No Breaking Changes**: The upgrade from Java 17 to Java 21 is seamless
+2. **Backward Compatibility**: All existing code continues to work
+3. **Gradle Compatibility**: Gradle 8.14.2 fully supports Java 21
+4. **Flink Compatibility**: Flink 2.0.0 officially supports Java 21
+5. **Docker Images**: Official Flink Docker images available for Java 21
+
+## Next Steps
+
+1. **Enable Preview Features** (optional): Add `--enable-preview` to JVM args to use String Templates
+2. **Code Modernization**: Gradually adopt Java 21 features in new code
+3. **Performance Testing**: Benchmark performance improvements
+4. **Team Training**: Educate team on new Java 21 features
+
+## Troubleshooting
+
+If you encounter issues:
+1. Verify Java 21 is correctly installed: `java -version`
+2. Clean and rebuild: `./gradlew clean build`
+3. Check Flink compatibility: `./gradlew validateSetup`
+4. Review deprecation warnings for future API changes
+
+## Additional Resources
+
+- [Java 21 Release Notes](https://openjdk.org/projects/jdk/21/)
+- [Apache Flink Java 21 Compatibility](https://flink.apache.org/)
+- [Gradle Java 21 Support](https://docs.gradle.org/current/userguide/compatibility.html)

--- a/docs/java21-upgrade-guide.md
+++ b/docs/java21-upgrade-guide.md
@@ -9,15 +9,15 @@ This Flink 101 Java project has been successfully upgraded from Java 17 to Java 
 ### 1. Build Configuration Updates
 
 - **build.gradle.kts**: Updated `sourceCompatibility` and `targetCompatibility` from `VERSION_17` to `VERSION_21`
-- **docker-compose.yml**: Updated Flink images from `flink:2.0.0-scala_2.12-java17` to `flink:2.0.0-scala_2.12-java21`
+- **docker-compose.yml**: Updated Flink images to `flink:2.2.0-scala_2.12-java21` (Java 21 runtime)
 - **GitHub Actions**: Updated CI workflow to use Java 21 exclusively
 
 ### 2. Compatibility Verification
 
 ✅ **Build Status**: All builds successful  
-✅ **Test Status**: All tests passing  
+ℹ️ **Test Status**: No automated test sources yet — Gradle `test` reports `NO-SOURCE`; CI runs a smoke test (build + lesson 1 + shadow jar)  
 ✅ **Runtime Status**: All lessons execute correctly  
-✅ **Flink Compatibility**: Flink 2.0.0 fully supports Java 21  
+✅ **Flink Compatibility**: Flink 2.2.0 fully supports Java 21  
 
 ### 3. Deprecation Warnings
 
@@ -145,8 +145,8 @@ For Kafka producers/consumers or external API calls, virtual threads can improve
 
 1. **No Breaking Changes**: The upgrade from Java 17 to Java 21 is seamless
 2. **Backward Compatibility**: All existing code continues to work
-3. **Gradle Compatibility**: Gradle 8.14.2 fully supports Java 21
-4. **Flink Compatibility**: Flink 2.0.0 officially supports Java 21
+3. **Gradle Compatibility**: Gradle 9.5.0 fully supports Java 21
+4. **Flink Compatibility**: Flink 2.2.0 officially supports Java 21
 5. **Docker Images**: Official Flink Docker images available for Java 21
 
 ## Next Steps

--- a/docs/kafka-producer-setup.md
+++ b/docs/kafka-producer-setup.md
@@ -42,9 +42,9 @@ This enables continuous testing of Flink streaming applications like OrderProces
 Ensure your `.env` file contains the required Confluent Cloud credentials:
 
 ```bash
-export CNFL_KAFKA_BROKER=your-broker-endpoint:9092
-export CNFL_KC_API_KEY=your-kafka-api-key
-export CNFL_KC_API_SECRET=your-kafka-api-secret
+export CFLT_KAFKA_BROKER=your-broker-endpoint:9092
+export CFLT_KC_API_KEY=your-kafka-api-key
+export CFLT_KC_API_SECRET=your-kafka-api-secret
 ```
 
 Load the environment variables:
@@ -70,9 +70,9 @@ Run the producer to generate continuous order data:
 ```
 === Kafka Order Producer ===
 Connecting to Confluent Cloud Kafka...
-✓ Loaded CNFL_KAFKA_BROKER from environment
-✓ Loaded CNFL_KC_API_KEY from environment
-✓ Loaded CNFL_KC_API_SECRET from environment
+✓ Loaded CFLT_KAFKA_BROKER from environment
+✓ Loaded CFLT_KC_API_KEY from environment
+✓ Loaded CFLT_KC_API_SECRET from environment
 ✓ Kafka producer configured for Confluent Cloud
 Starting continuous order generation... Press Ctrl+C to stop.
 Sent Order> Order{id=order_00001, customer=customer_002, amount=156.78, category=Electronics}

--- a/docs/kafka-producer-setup.md
+++ b/docs/kafka-producer-setup.md
@@ -69,11 +69,11 @@ Run the producer to generate continuous order data:
 **Expected Output:**
 ```
 === Kafka Order Producer ===
-Connecting to Confluent Cloud Kafka...
+Connecting to Kafka...
 ✓ Loaded CFLT_KAFKA_BROKER from environment
 ✓ Loaded CFLT_KC_API_KEY from environment
 ✓ Loaded CFLT_KC_API_SECRET from environment
-✓ Kafka producer configured for Confluent Cloud
+✓ Kafka producer configured for Confluent Cloud (SASL_SSL)
 Starting continuous order generation... Press Ctrl+C to stop.
 Sent Order> Order{id=order_00001, customer=customer_002, amount=156.78, category=Electronics}
   ✓ Delivered to partition 1 at offset 12345

--- a/docs/lessons/lesson02/README.md
+++ b/docs/lessons/lesson02/README.md
@@ -96,13 +96,13 @@ Use Confluent Cloud Console to send test messages to your topic:
 When running successfully, you should see:
 ```
 === Flink Lesson 2: Kafka Integration ===
-Connecting to Confluent Cloud Kafka...
+Connecting to Kafka...
 ✓ Loaded CFLT_KAFKA_BROKER from environment
 ✓ Loaded CFLT_KC_API_KEY from environment
 ✓ Loaded CFLT_KC_API_SECRET from environment
 Bootstrap servers: pkc-rgm37.us-west-2.aws.confluent.cloud:9092
 Using topic: orders
-✓ Kafka properties configured for Confluent Cloud
+✓ Kafka consumer configured for Confluent Cloud (SASL_SSL)
 Starting Kafka consumer... Press Ctrl+C to stop.
 Processing message: {"orderId": "12345", "customerId": "cust_001", "amount": 99.99}
 Kafka Messages> [1721058123456] {"orderId": "12345", "customerId": "cust_001", "amount": 99.99}

--- a/docs/lessons/lesson02/README.md
+++ b/docs/lessons/lesson02/README.md
@@ -27,9 +27,9 @@ By the end of this lesson, you will understand:
 ### Environment Variables Required
 Make sure your `.env` file contains:
 ```bash
-export CNFL_KAFKA_BROKER=your-broker-endpoint
-export CNFL_KC_API_KEY=your-kafka-api-key
-export CNFL_KC_API_SECRET=your-kafka-api-secret
+export CFLT_KAFKA_BROKER=your-broker-endpoint
+export CFLT_KC_API_KEY=your-kafka-api-key
+export CFLT_KC_API_SECRET=your-kafka-api-secret
 ```
 
 ## Key Concepts
@@ -97,9 +97,9 @@ When running successfully, you should see:
 ```
 === Flink Lesson 2: Kafka Integration ===
 Connecting to Confluent Cloud Kafka...
-✓ Loaded CNFL_KAFKA_BROKER from environment
-✓ Loaded CNFL_KC_API_KEY from environment
-✓ Loaded CNFL_KC_API_SECRET from environment
+✓ Loaded CFLT_KAFKA_BROKER from environment
+✓ Loaded CFLT_KC_API_KEY from environment
+✓ Loaded CFLT_KC_API_SECRET from environment
 Bootstrap servers: pkc-rgm37.us-west-2.aws.confluent.cloud:9092
 Using topic: orders
 ✓ Kafka properties configured for Confluent Cloud
@@ -133,7 +133,7 @@ Kafka Messages> [1721058123456] {"orderId": "12345", "customerId": "cust_001", "
 - Or modify the topic name in the code to use an existing topic
 
 #### 4. Environment Variables Not Found
-**Error**: `Environment variable CNFL_KC_API_KEY not found`
+**Error**: `Environment variable CFLT_KC_API_KEY not found`
 **Solution**:
 - Run `source .env` before executing the program
 - Verify `.env` file exists and contains required variables

--- a/docs/lessons/lesson03/README.md
+++ b/docs/lessons/lesson03/README.md
@@ -41,9 +41,9 @@ By the end of this lesson, you will understand:
 ### Environment Variables Required
 Make sure your `.env` file contains:
 ```bash
-export CNFL_KAFKA_BROKER=your-broker-endpoint:9092
-export CNFL_KC_API_KEY=your-kafka-api-key
-export CNFL_KC_API_SECRET=your-kafka-api-secret
+export CFLT_KAFKA_BROKER=your-broker-endpoint:9092
+export CFLT_KC_API_KEY=your-kafka-api-key
+export CFLT_KC_API_SECRET=your-kafka-api-secret
 ```
 
 ### Data Generator Setup

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,289 @@
+# Apache Flink 2.0 Demo Suite - Simplified Improvement Plan
+
+**Document Version:** 2.0  
+**Date:** July 15, 2025  
+**Focus:** Demo readability and educational expressiveness
+
+## Executive Summary
+
+This simplified improvement plan focuses on enhancing the Apache Flink 2.0 Demo Suite as an educational tool that prioritizes code readability, simplicity, and learning effectiveness over production-grade complexity. The goal is to create clear, expressive examples that help developers understand Flink concepts without being overwhelmed by enterprise-level infrastructure concerns.
+
+## Core Principles
+
+- **Readability First**: Code should be self-explanatory and easy to follow
+- **Educational Focus**: Every feature should serve the learning objectives
+- **Simplicity Over Robustness**: Prefer simple, clear solutions over complex, production-ready ones
+- **Quick Setup**: Minimize barriers to getting started
+- **Expressive Examples**: Code should clearly demonstrate Flink concepts
+
+## 1. Code Clarity & Readability
+
+### 1.1 Simplified Code Examples
+
+**Current State:** Code examples may include unnecessary complexity  
+**Proposed Improvement:** Focus on clear, minimal examples that demonstrate core concepts
+
+**Rationale:** Demo applications should be immediately understandable. Complex error handling, optimization, and edge cases can obscure the main learning points.
+
+**Implementation:**
+- Use descriptive variable names and clear method signatures
+- Add inline comments explaining Flink-specific concepts
+- Remove unnecessary try-catch blocks and error handling complexity
+- Use simple data types (String, Integer) instead of complex POJOs where possible
+- Include "what this does" comments for each transformation step
+
+**Example Transformation:**
+```java
+// BEFORE (production-style)
+public class OrderProcessor implements ProcessFunction<OrderEvent, EnrichedOrder> {
+    private transient ValueState<CustomerProfile> customerState;
+    
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        ValueStateDescriptor<CustomerProfile> descriptor = 
+            new ValueStateDescriptor<>("customer", CustomerProfile.class);
+        customerState = getRuntimeContext().getState(descriptor);
+    }
+    
+    @Override
+    public void processElement(OrderEvent order, Context ctx, Collector<EnrichedOrder> out) 
+            throws Exception {
+        // Complex processing logic...
+    }
+}
+
+// AFTER (demo-style)
+public class SimpleOrderProcessor extends ProcessFunction<String, String> {
+    @Override
+    public void processElement(String order, Context ctx, Collector<String> out) {
+        // Transform order: add timestamp and customer info
+        String enrichedOrder = order + " [processed at " + System.currentTimeMillis() + "]";
+        out.collect(enrichedOrder);
+    }
+}
+```
+
+### 1.2 Clear Documentation Structure
+
+**Current State:** Documentation may be too comprehensive for demo purposes  
+**Proposed Improvement:** Concise, example-focused documentation
+
+**Implementation:**
+- Start each lesson with a simple "What you'll learn" section
+- Include a complete, runnable example at the beginning
+- Use step-by-step explanations with code snippets
+- Add "Try this" sections for hands-on experimentation
+- Keep explanations focused on Flink concepts, not infrastructure
+
+## 2. Simplified Setup & Configuration
+
+### 2.1 Minimal Docker Configuration
+
+**Current State:** Docker setup may include unnecessary services and complexity  
+**Proposed Improvement:** Bare minimum Docker setup for learning
+
+**Implementation:**
+- Single docker-compose.yml with only essential services
+- Remove health checks, monitoring, and production optimizations
+- Use default configurations where possible
+- Include clear comments explaining what each service does
+- Provide simple start/stop commands
+
+**Example Docker Compose:**
+```yaml
+# Simple Flink cluster for learning
+services:
+  jobmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    ports:
+      - "8081:8081"  # Flink Web UI
+    environment:
+      - FLINK_PROPERTIES=jobmanager.rpc.address: jobmanager
+    
+  taskmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    depends_on:
+      - jobmanager
+    environment:
+      - FLINK_PROPERTIES=jobmanager.rpc.address: jobmanager
+```
+
+### 2.2 Straightforward Build Configuration
+
+**Current State:** Build configuration may include unnecessary plugins and complexity  
+**Proposed Improvement:** Simple Gradle setup focused on running examples
+
+**Implementation:**
+- Single build.gradle file with minimal dependencies
+- Remove code quality plugins, security scanning, etc.
+- Focus on easy execution with simple gradle tasks
+- Include only essential Flink dependencies
+- Clear comments explaining what each dependency is for
+
+## 3. Educational Effectiveness
+
+### 3.1 Progressive Learning Path
+
+**Current State:** Lessons may jump too quickly between concepts  
+**Proposed Improvement:** Gentle progression with clear building blocks
+
+**Implementation:**
+- Each lesson builds on exactly one new concept
+- Include "recap" sections showing how concepts connect
+- Use consistent data examples across lessons (e.g., same order/customer theme)
+- Add "experiment" sections encouraging code modification
+- Provide expected output examples for each step
+
+### 3.2 Hands-On Experimentation
+
+**Current State:** Examples may be too rigid  
+**Proposed Improvement:** Encourage exploration and modification
+
+**Implementation:**
+- Include "Try changing this" suggestions in code comments
+- Provide multiple data sets for testing
+- Add "What happens if..." questions
+- Include simple debugging tips specific to each lesson
+- Show common mistakes and how to fix them
+
+## 4. Minimal Testing Approach
+
+### 4.1 Simple Validation
+
+**Current State:** May include complex testing frameworks  
+**Proposed Improvement:** Basic validation that examples work
+
+**Implementation:**
+- Simple main() methods that can be run directly
+- Basic assertions using standard Java (no testing frameworks)
+- Include expected output in comments
+- Focus on "does it run" rather than comprehensive testing
+- Provide troubleshooting tips for common issues
+
+**Example:**
+```java
+public class Lesson01WordCount {
+    public static void main(String[] args) throws Exception {
+        // Expected output: word counts printed to console
+        // If you see "flink -> 2", "streaming -> 1", etc., it's working!
+        
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // ... rest of example
+    }
+}
+```
+
+## 5. Streamlined Confluent Cloud Integration
+
+### 5.1 Essential Cloud Setup
+
+**Current State:** May include complex cloud configurations  
+**Proposed Improvement:** Minimal setup to demonstrate cloud connectivity
+
+**Implementation:**
+- Simple environment variable configuration
+- Basic authentication without complex security layers
+- Clear step-by-step cloud setup guide
+- Focus on getting connected, not on cloud best practices
+- Include troubleshooting for common connection issues
+
+### 5.2 Clear Cloud Examples
+
+**Implementation:**
+- Use simple topic names and schemas
+- Include sample data generation scripts
+- Show exactly what to expect in Confluent Cloud UI
+- Provide clear "success" indicators
+- Keep cloud-specific code separate and optional
+
+## 6. Focused Content Areas
+
+### 6.1 Core Flink Concepts Only
+
+**What to Include:**
+- DataStream API basics
+- Simple transformations (map, filter, keyBy)
+- Basic windowing
+- Kafka source/sink connectivity
+- Table API fundamentals
+- Basic SQL operations
+
+**What to Exclude:**
+- Complex state management
+- Advanced performance tuning
+- Production deployment patterns
+- Comprehensive error handling
+- Security configurations
+- Monitoring and observability
+
+### 6.2 Learning-Focused Features
+
+**Implementation:**
+- Visual diagrams showing data flow
+- Before/after data examples
+- Step-by-step execution traces
+- Simple debugging techniques
+- Common beginner mistakes and solutions
+
+## Implementation Approach
+
+### Phase 1: Simplify Existing Content (Week 1)
+- Review all lesson code for unnecessary complexity
+- Remove production-oriented configurations
+- Simplify Docker and build setup
+- Focus on core learning objectives
+
+### Phase 2: Enhance Readability (Week 2)
+- Add clear comments and documentation
+- Improve variable names and code structure
+- Create consistent examples across lessons
+- Add experimentation suggestions
+
+### Phase 3: Validate Learning Experience (Week 3)
+- Test all examples with fresh eyes
+- Ensure quick setup and execution
+- Verify learning progression makes sense
+- Gather feedback from beginner developers
+
+## Success Metrics (Simplified)
+
+### Primary Goals
+- **Setup Time**: Under 10 minutes from clone to first running example
+- **Code Clarity**: Beginners can understand examples without external help
+- **Learning Progression**: Each lesson builds naturally on the previous
+- **Execution Success**: 100% of examples run successfully with provided setup
+
+### Educational Effectiveness
+- **Concept Clarity**: Learners can explain what each code block does
+- **Hands-On Engagement**: Learners modify and experiment with examples
+- **Progression Confidence**: Learners feel ready for the next lesson
+- **Practical Understanding**: Learners can apply concepts to new scenarios
+
+## What We're NOT Doing
+
+To maintain focus on educational value, this plan explicitly excludes:
+
+- ❌ Comprehensive testing frameworks
+- ❌ CI/CD pipelines and automation
+- ❌ Security hardening and compliance
+- ❌ Performance optimization and monitoring
+- ❌ Production deployment patterns
+- ❌ Complex error handling and resilience
+- ❌ Multi-environment configurations
+- ❌ Community platforms and ecosystem integration
+- ❌ Advanced DevOps practices
+
+## Conclusion
+
+This simplified improvement plan transforms the Apache Flink 2.0 Demo Suite into a focused educational tool that prioritizes learning effectiveness over production readiness. By emphasizing code clarity, simple setup, and hands-on experimentation, we create an environment where developers can focus on understanding Flink concepts without being distracted by enterprise-level complexity.
+
+The approach recognizes that demo applications serve a different purpose than production systems. They should be immediately understandable, easy to modify, and focused on teaching core concepts rather than showcasing comprehensive best practices.
+
+**Key Principles:**
+- Readability trumps robustness
+- Simplicity enables learning
+- Examples should be self-explanatory
+- Setup should be friction-free
+- Focus on Flink concepts, not infrastructure
+
+This plan ensures that learners spend their time understanding stream processing concepts rather than wrestling with complex configurations and production-grade infrastructure concerns.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,908 @@
+# Apache Flink 2.0 Demo Suite PRD: 5-Lesson Developer Course
+
+## Executive Summary
+
+This Product Requirements Document outlines a comprehensive 5-lesson Apache Flink 2.0 demo suite designed for developers new to stream processing. 
+The course leverages Docker for local deployment, Confluent Cloud for Kafka services, and follows a progressive, hands-on learning approach with 30-minute code-driven lessons.
+
+**Key innovations in Flink 2.0** include disaggregated state management, materialized tables, enhanced stream-batch unification, and cloud-native architecture. The course capitalizes on these features while providing a solid foundation in both DataStream and Table API approaches.
+
+## Technical Architecture
+
+### Infrastructure Components
+
+**Local Development Stack:**
+- **Apache Flink 2.0**: Latest version with Java 17 support
+- **Docker**: Container orchestration for Flink cluster
+- **Confluent Cloud**: Managed Kafka and Schema Registry services
+- **Schema Registry**: Avro serialization and schema evolution
+
+**Supported Environments:**
+- Docker Desktop with 4GB+ memory allocation
+- Java 17 (minimum Java 11)
+- Gradle 8.0+ with Kotlin DSL
+- IDE with Flink plugin support
+
+### Project Structure
+
+```
+flink-demo-suite/
+├── docker-compose.yml
+├── config/
+│   ├── flink-conf.yaml
+│   └── log4j2.properties
+├── lessons/
+│   ├── lesson01-datastream-memory/
+│   ├── lesson02-kafka-consumption/
+│   ├── lesson03-data-processing/
+│   ├── lesson04-materialized-views/
+│   └── lesson05-table-api-sql/
+├── shared/
+│   ├── data-generators/
+│   ├── utils/
+│   └── test-harness/
+├── docs/
+│   ├── setup-guide.md
+│   ├── troubleshooting.md
+│   └── confluent-cloud-setup.md
+└── README.md
+```
+
+## Lesson Plans
+
+### Lesson 1: Data Stream API with In-Memory Data
+
+**Duration:** 30 minutes  
+**Complexity:** Beginner  
+**Focus:** DataStream API fundamentals
+
+#### Learning Objectives
+- Implement basic DataStream transformations using in-memory data sources
+- Configure StreamExecutionEnvironment for local development
+- Apply map, filter, and window operations to streaming data
+
+#### Technical Prerequisites
+- Basic Java programming knowledge
+- Understanding of collections and iterators
+- Docker installation and basic container concepts
+
+#### Implementation Details
+
+**Phase 1: Environment Setup (5 minutes)**
+
+```java
+// StreamExecutionEnvironment configuration
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+env.setParallelism(1); // Single parallelism for learning
+env.disableOperatorChaining(); // Enable step-by-step debugging
+```
+
+**Phase 2: Core Implementation (20 minutes)**
+```java
+public class StreamingWordCount {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        
+        // Create in-memory data source
+        DataStreamSource<String> textLines = env.fromElements(
+            "apache flink streaming",
+            "real time data processing",
+            "flink datastream api"
+        );
+        
+        // Apply transformations
+        DataStream<Tuple2<String, Integer>> wordCounts = textLines
+            .flatMap(new Tokenizer())
+            .keyBy(value -> value.f0)
+            .window(TumblingProcessingTimeWindows.of(Time.seconds(5)))
+            .sum(1);
+        
+        wordCounts.print();
+        env.execute("In-Memory Word Count");
+    }
+}
+```
+
+**Phase 3: Validation (5 minutes)**
+- Test with different data inputs
+- Verify windowing behavior
+- Observe parallelism effects
+
+#### Sample Code Structure
+```java
+// Tokenizer implementation
+public static class Tokenizer implements FlatMapFunction<String, Tuple2<String, Integer>> {
+    @Override
+    public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {
+        for (String word : value.toLowerCase().split("\\W+")) {
+            if (word.length() > 0) {
+                out.collect(new Tuple2<>(word, 1));
+            }
+        }
+    }
+}
+```
+
+#### Expected Outcomes
+- Successful execution of streaming job
+- Understanding of DataStream transformation pipeline
+- Basic debugging and monitoring capability
+
+#### Docker Configuration
+```yaml
+# lesson01-docker-compose.yml
+services:
+  flink-jobmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    ports:
+      - "8081:8081"
+    environment:
+      - FLINK_PROPERTIES=jobmanager.rpc.address: flink-jobmanager
+    volumes:
+      - ./config:/opt/flink/conf
+      - ./lesson01:/workspace
+
+  flink-taskmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    depends_on:
+      - flink-jobmanager
+    environment:
+      - FLINK_PROPERTIES=jobmanager.rpc.address: flink-jobmanager
+    volumes:
+      - ./config:/opt/flink/conf
+      - ./lesson01:/workspace
+```
+
+### Lesson 2: Consuming Data from Kafka
+
+**Duration:** 30 minutes  
+**Complexity:** Intermediate  
+**Focus:** Kafka integration and external data consumption
+
+#### Learning Objectives
+- Configure Kafka source connectors with Confluent Cloud
+- Implement proper authentication and security for cloud Kafka
+- Handle real-time data ingestion with watermarking strategies
+
+#### Technical Prerequisites
+- Completion of Lesson 1
+- Confluent Cloud account with Kafka cluster
+- Basic understanding of message queues
+
+#### Implementation Details
+
+**Phase 1: Confluent Cloud Setup (8 minutes)**
+```java
+// Kafka configuration for Confluent Cloud
+Properties props = new Properties();
+props.setProperty("bootstrap.servers", "your-cluster.us-west-2.aws.confluent.cloud:9092");
+props.setProperty("security.protocol", "SASL_SSL");
+props.setProperty("sasl.mechanism", "PLAIN");
+props.setProperty("sasl.jaas.config", 
+    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+    "username=\"" + System.getenv("KAFKA_API_KEY") + "\" " +
+    "password=\"" + System.getenv("KAFKA_API_SECRET") + "\";");
+props.setProperty("group.id", "flink-demo-consumer");
+```
+
+**Phase 2: Kafka Source Implementation (15 minutes)**
+```java
+public class KafkaConsumerExample {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        
+        // Configure Kafka source
+        KafkaSource<String> source = KafkaSource.<String>builder()
+            .setBootstrapServers("your-cluster.us-west-2.aws.confluent.cloud:9092")
+            .setTopics("demo-events")
+            .setStartingOffsets(OffsetsInitializer.latest())
+            .setValueOnlyDeserializer(new SimpleStringSchema())
+            .setProperties(getKafkaProps())
+            .build();
+        
+        // Create watermark strategy
+        WatermarkStrategy<String> watermarkStrategy = WatermarkStrategy
+            .<String>forBoundedOutOfOrderness(Duration.ofSeconds(5))
+            .withTimestampAssigner((event, timestamp) -> System.currentTimeMillis());
+        
+        // Process stream
+        DataStream<String> stream = env.fromSource(source, watermarkStrategy, "Kafka Source");
+        
+        stream
+            .map(new EventProcessor())
+            .print();
+        
+        env.execute("Kafka Consumer Demo");
+    }
+}
+```
+
+**Phase 3: Monitoring and Debugging (7 minutes)**
+- Monitor Kafka consumer lag
+- Validate message consumption rates
+- Test with different offset strategies
+
+#### Confluent Cloud Integration Details
+```bash
+# Environment variables setup
+export KAFKA_API_KEY="your-api-key"
+export KAFKA_API_SECRET="your-api-secret"
+export KAFKA_BOOTSTRAP_SERVERS="your-cluster.us-west-2.aws.confluent.cloud:9092"
+
+# Topic creation
+confluent kafka topic create demo-events --partitions 3 --cluster lkc-cluster-id
+```
+
+#### Expected Outcomes
+- Successful connection to Confluent Cloud Kafka
+- Real-time data consumption from external source
+- Understanding of watermarking and event time processing
+
+### Lesson 3: Data Processing
+
+**Duration:** 30 minutes  
+**Complexity:** Intermediate  
+**Focus:** Advanced stream processing patterns
+
+#### Learning Objectives
+- Implement stateful processing with keyed streams
+- Apply window operations for time-based aggregations
+- Handle late-arriving data and out-of-order events
+
+#### Technical Prerequisites
+- Completion of Lessons 1-2
+- Understanding of event time vs processing time
+- Basic knowledge of windowing concepts
+
+#### Implementation Details
+
+**Phase 1: Stateful Processing Setup (10 minutes)**
+```java
+public class OrderProcessingJob {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        
+        // Configure checkpointing for fault tolerance
+        env.enableCheckpointing(60000, CheckpointingMode.EXACTLY_ONCE);
+        
+        // Order event stream
+        DataStream<OrderEvent> orderStream = env
+            .fromSource(getKafkaSource(), getWatermarkStrategy(), "Orders")
+            .map(new OrderEventDeserializer());
+        
+        // Process orders by customer
+        DataStream<CustomerOrderSummary> customerSummaries = orderStream
+            .keyBy(OrderEvent::getCustomerId)
+            .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+            .aggregate(new OrderAggregator(), new SummaryWindowFunction());
+        
+        customerSummaries.print();
+        env.execute("Order Processing");
+    }
+}
+```
+
+**Phase 2: Window Operations and Aggregations (15 minutes)**
+```java
+// Custom aggregation function
+public static class OrderAggregator implements AggregateFunction<OrderEvent, OrderAccumulator, OrderSummary> {
+    @Override
+    public OrderAccumulator createAccumulator() {
+        return new OrderAccumulator();
+    }
+    
+    @Override
+    public OrderAccumulator add(OrderEvent order, OrderAccumulator accumulator) {
+        accumulator.totalAmount += order.getAmount();
+        accumulator.orderCount++;
+        return accumulator;
+    }
+    
+    @Override
+    public OrderSummary getResult(OrderAccumulator accumulator) {
+        return new OrderSummary(accumulator.orderCount, accumulator.totalAmount);
+    }
+    
+    @Override
+    public OrderAccumulator merge(OrderAccumulator a, OrderAccumulator b) {
+        return new OrderAccumulator(a.orderCount + b.orderCount, a.totalAmount + b.totalAmount);
+    }
+}
+```
+
+**Phase 3: Late Data Handling (5 minutes)**
+```java
+// Configure allowed lateness
+DataStream<CustomerOrderSummary> results = orderStream
+    .keyBy(OrderEvent::getCustomerId)
+    .window(TumblingEventTimeWindows.of(Time.minutes(5)))
+    .allowedLateness(Time.minutes(2))
+    .sideOutputLateData(lateDataTag)
+    .aggregate(new OrderAggregator());
+
+// Handle late data
+DataStream<OrderEvent> lateOrders = results.getSideOutput(lateDataTag);
+lateOrders.print("Late Data");
+```
+
+#### Expected Outcomes
+- Functioning stateful stream processing application
+- Understanding of windowing and aggregation patterns
+- Capability to handle late-arriving data
+
+### Lesson 4: Creating Materialized Views
+
+**Duration:** 30 minutes  
+**Complexity:** Advanced  
+**Focus:** Materialized tables and unified stream-batch processing
+
+#### Learning Objectives
+- Implement materialized tables using Flink 2.0 features
+- Configure automatic refresh strategies
+- Integrate with persistent storage systems
+
+#### Technical Prerequisites
+- Completion of Lessons 1-3
+- Understanding of SQL and table concepts
+- Basic knowledge of database operations
+
+#### Implementation Details
+
+**Phase 1: Confluent Cloud Materialized Table Creation (10 minutes)**
+```sql
+-- In Confluent Cloud, Kafka topics automatically appear as queryable tables
+-- First, verify your topic exists and is accessible
+SHOW TABLES;
+
+-- Since Confluent Cloud automatically maps Kafka topics to Flink tables,
+-- you can directly query your order_events topic (if it exists)
+DESCRIBE order_events;
+
+-- Create a materialized view using Confluent Cloud Flink SQL
+-- Note: Confluent Cloud handles the infrastructure automatically
+CREATE TABLE customer_metrics (
+    customer_id STRING,
+    total_orders BIGINT,
+    total_amount DECIMAL(10,2),
+    avg_order_amount DECIMAL(10,2),
+    last_order_time TIMESTAMP(3),
+    PRIMARY KEY (customer_id) NOT ENFORCED
+) WITH (
+    'changelog.mode' = 'upsert'
+);
+
+-- Populate the materialized view with continuous query
+INSERT INTO customer_metrics
+SELECT 
+    customer_id,
+    COUNT(*) as total_orders,
+    SUM(amount) as total_amount,
+    AVG(amount) as avg_order_amount,
+    MAX(order_time) as last_order_time
+FROM order_events
+GROUP BY customer_id;
+
+-- Query the materialized view
+SELECT * FROM customer_metrics WHERE total_amount > 1000;
+```
+
+**Phase 2: Confluent Cloud Table Environment Setup (15 minutes)**
+```java
+public class ConfluentCloudMaterializedViewExample {
+    public static void main(String[] args) throws Exception {
+        // For local Flink connecting to Confluent Cloud
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+        
+        // Configure Confluent Cloud connection
+        tableEnv.executeSql("""
+            CREATE CATALOG confluent_cloud WITH (
+                'type' = 'confluent-cloud',
+                'bootstrap.servers' = '%s',
+                'properties.security.protocol' = 'SASL_SSL',
+                'properties.sasl.mechanism' = 'PLAIN',
+                'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username="%s" password="%s";'
+            )
+            """.formatted(
+                System.getenv("KAFKA_BOOTSTRAP_SERVERS"),
+                System.getenv("KAFKA_API_KEY"),
+                System.getenv("KAFKA_API_SECRET")
+            ));
+        
+        // Use Confluent Cloud catalog
+        tableEnv.executeSql("USE CATALOG confluent_cloud");
+        
+        // Show available databases (Kafka clusters) and tables (topics)
+        tableEnv.executeSql("SHOW DATABASES").print();
+        tableEnv.executeSql("USE DATABASE lkc_cluster_id"); // Your cluster ID
+        tableEnv.executeSql("SHOW TABLES").print();
+        
+        // Query materialized view - leveraging automatic topic-to-table mapping
+        Table results = tableEnv.sqlQuery(
+            "SELECT customer_id, total_orders, total_amount " +
+            "FROM customer_metrics " +
+            "WHERE total_amount > 1000"
+        );
+        
+        // Convert to DataStream for further processing
+        DataStream<Row> resultStream = tableEnv.toDataStream(results);
+        resultStream.print();
+        
+        env.execute("Confluent Cloud Materialized View Demo");
+    }
+}
+```
+
+**Phase 3: Cross-Environment Queries (5 minutes)**
+```java
+// Demonstrate Confluent Cloud's cross-environment query capability
+Table crossEnvResults = tableEnv.sqlQuery(
+    "SELECT o.customer_id, o.total_amount, p.product_name " +
+    "FROM `production-env`.`main-cluster`.customer_metrics o " +
+    "JOIN `catalog-env`.`product-cluster`.products p " +
+    "ON o.customer_id = p.customer_id " +
+    "WHERE o.total_amount > 1000"
+);
+
+// This showcases Confluent Cloud's unique ability to query across 
+// environments and clusters within the same region
+crossEnvResults.execute().print();
+```
+
+#### Expected Outcomes
+- Functioning materialized view with automatic data sync between Kafka topics and Flink tables
+- Understanding of Confluent Cloud's unified metadata management
+- Capability to perform cross-environment queries within the same region
+- Experience with Confluent Cloud's serverless, auto-scaling Flink service
+
+### Lesson 5: Table API and SQL Approach
+
+**Duration:** 30 minutes  
+**Complexity:** Intermediate  
+**Focus:** Comparative implementation using Table API/SQL
+
+#### Learning Objectives
+- Recreate previous lesson functionality using Table API and SQL
+- Compare DataStream vs Table API approaches
+- Implement complex analytical queries using SQL
+
+#### Technical Prerequisites
+- Completion of Lessons 1-4
+- SQL query writing experience
+- Understanding of relational data concepts
+
+#### Implementation Details
+
+**Phase 1: Table API Implementation (12 minutes)**
+```java
+public class TableAPIExample {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+        
+        // Create source table
+        tableEnv.executeSql(getSourceTableDDL());
+        
+        // Table API transformations
+        Table sourceTable = tableEnv.from("order_events");
+        Table processedTable = sourceTable
+            .select($("customer_id"), $("amount"), $("order_time"))
+            .filter($("amount").isGreater(100))
+            .groupBy($("customer_id"))
+            .select($("customer_id"), 
+                   $("amount").sum().as("total_amount"),
+                   $("amount").count().as("order_count"));
+        
+        // Execute query
+        TableResult result = processedTable.execute();
+        result.print();
+    }
+}
+```
+
+**Phase 2: Confluent Cloud Flink SQL Implementation (13 minutes)**
+```sql
+-- Confluent Cloud automatically maps Kafka topics to Flink tables
+-- Show available catalogs (environments), databases (clusters), and tables (topics)
+SHOW CATALOGS;
+USE CATALOG `my-environment`;
+SHOW DATABASES;
+USE DATABASE `lkc-cluster-id`;
+SHOW TABLES;
+
+-- Confluent Cloud Flink SQL with time window functions
+SELECT 
+    customer_id,
+    COUNT(*) as order_count,
+    SUM(amount) as total_amount,
+    AVG(amount) as avg_order_amount,
+    -- Use Confluent Cloud's built-in window functions
+    window_start,
+    window_end
+FROM TABLE(
+    TUMBLE(TABLE order_events, DESCRIPTOR($rowtime), INTERVAL '5' MINUTE)
+)
+WHERE amount > 50
+GROUP BY customer_id, window_start, window_end
+HAVING COUNT(*) > 2
+ORDER BY total_amount DESC;
+
+-- Advanced analytics with Confluent Cloud features
+SELECT 
+    customer_id,
+    total_amount,
+    -- Ranking within partition
+    ROW_NUMBER() OVER (PARTITION BY DATE_FORMAT($rowtime, 'yyyy-MM-dd') ORDER BY total_amount DESC) as daily_rank,
+    -- Percentile calculations
+    PERCENT_RANK() OVER (ORDER BY total_amount) as amount_percentile,
+    -- Cross-environment join (unique to Confluent Cloud)
+    p.product_category
+FROM customer_metrics c
+JOIN `catalog-env`.`product-cluster`.products p 
+    ON c.customer_id = p.customer_id
+WHERE c.total_amount > 1000;
+```
+
+**Phase 3: Performance Comparison (5 minutes)**
+```java
+// Performance optimization settings
+tableEnv.getConfig().set("table.exec.mini-batch.enabled", "true");
+tableEnv.getConfig().set("table.exec.mini-batch.allow-latency", "5s");
+tableEnv.getConfig().set("table.exec.mini-batch.size", "1000");
+tableEnv.getConfig().set("table.optimizer.agg-phase-strategy", "TWO_PHASE");
+```
+
+#### Expected Outcomes
+- Equivalent functionality using Table API/SQL with Confluent Cloud integration
+- Understanding of when to use DataStream API vs Table API/SQL approaches
+- Experience with Confluent Cloud's cross-environment query capabilities
+- Performance optimization awareness for cloud-native Flink deployments
+
+## Docker Configuration Requirements
+
+### Base Configuration
+```yaml
+# docker-compose.yml
+services:
+  jobmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    ports:
+      - "8081:8081"
+      - "6123:6123"
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        rest.address: jobmanager
+        rest.port: 8081
+        rest.flamegraph.enabled: true
+        taskmanager.numberOfTaskSlots: 4
+        parallelism.default: 1
+        execution.checkpointing.interval: 60s
+        state.backend: rocksdb
+        state.backend.incremental: true
+    volumes:
+      - ./config:/opt/flink/conf
+      - ./lib:/opt/flink/lib
+      - ./data:/data
+      - ./checkpoints:/checkpoints
+    networks:
+      - flink-demo
+
+  taskmanager:
+    image: flink:2.0.0-scala_2.12-java17
+    depends_on:
+      - jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 4
+        taskmanager.memory.process.size: 2g
+        taskmanager.memory.managed.fraction: 0.1
+    volumes:
+      - ./config:/opt/flink/conf
+      - ./lib:/opt/flink/lib
+      - ./data:/data
+      - ./checkpoints:/checkpoints
+    networks:
+      - flink-demo
+    scale: 2
+
+networks:
+  flink-demo:
+    driver: bridge
+```
+
+### Memory Configuration
+```yaml
+# Memory settings for development
+taskmanager:
+  memory:
+    process:
+      size: 2g
+    managed:
+      fraction: 0.1
+  numberOfTaskSlots: 4
+
+jobmanager:
+  memory:
+    process:
+      size: 1g
+    heap:
+      size: 768m
+```
+
+## Confluent Cloud Integration
+
+### Confluent Cloud Flink SQL Integration
+
+Since the demo suite uses Confluent Cloud for Kafka and Schema Registry, we'll leverage Confluent Cloud's unique Flink SQL capabilities that provide seamless integration between Kafka topics and Flink tables.
+
+#### Key Confluent Cloud Flink SQL Features
+- **Automatic Topic-to-Table Mapping**: Kafka topics automatically appear as queryable Flink tables
+- **Cross-Environment Queries**: Query data across different environments within the same region
+- **Unified Metadata Management**: No need to manually create table definitions for existing topics
+- **Serverless Execution**: Auto-scaling compute pools eliminate infrastructure management
+
+#### Environment Variables Setup
+```bash
+# Confluent Cloud Flink SQL connection
+export CONFLUENT_CLOUD_ENVIRONMENT_ID="env-12345"
+export CONFLUENT_CLOUD_CLUSTER_ID="lkc-cluster-id"  
+export FLINK_COMPUTE_POOL_ID="lfcp-pool-id"
+export KAFKA_BOOTSTRAP_SERVERS="your-cluster.us-west-2.aws.confluent.cloud:9092"
+export KAFKA_API_KEY="your-kafka-api-key"
+export KAFKA_API_SECRET="your-kafka-api-secret"
+```
+
+#### Topic Creation with Schema Registry
+```bash
+# Create topics with Avro schemas for the demo
+confluent kafka topic create demo-events --partitions 3 --cluster ${CONFLUENT_CLOUD_CLUSTER_ID}
+confluent kafka topic create order-events --partitions 6 --cluster ${CONFLUENT_CLOUD_CLUSTER_ID}
+confluent kafka topic create customer-metrics --partitions 3 --cluster ${CONFLUENT_CLOUD_CLUSTER_ID}
+
+# Register Avro schemas
+confluent schema-registry schema create --subject order-events-value --schema order-event-schema.avsc
+```
+
+### Gradle Build and Execution Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Run specific lesson
+./gradlew :lesson01-datastream-memory:run
+
+# Create fat JAR for Flink submission
+./gradlew shadowJar
+
+# Submit to Flink cluster
+docker exec flink-jobmanager flink run /workspace/build/libs/flink-demo.jar
+
+# Run tests
+./gradlew test
+
+# Clean and rebuild
+./gradlew clean build
+```
+
+### Confluent Cloud Flink SQL Examples
+
+Throughout the lessons, we'll use Confluent Cloud's specific Flink SQL dialect that provides enhanced features:
+
+#### Bounded vs Unbounded Processing
+```sql
+-- Bounded query (snapshot) - processes finite data
+SELECT customer_id, COUNT(*) as order_count 
+FROM order_events /*+ OPTIONS('scan.bounded.mode'='latest-offset') */
+GROUP BY customer_id;
+
+-- Unbounded query (streaming) - continuous processing
+SELECT customer_id, COUNT(*) as order_count 
+FROM order_events
+GROUP BY customer_id;
+```
+
+#### Time-based Operations
+```sql
+-- Window operations with event time
+SELECT 
+    customer_id,
+    COUNT(*) as orders_per_window,
+    window_start,
+    window_end
+FROM TABLE(
+    TUMBLE(TABLE order_events, DESCRIPTOR($rowtime), INTERVAL '1' HOUR)
+)
+GROUP BY customer_id, window_start, window_end;
+```
+
+#### Cross-Environment Queries
+```sql
+-- Query across different environments (unique Confluent Cloud feature)
+SELECT 
+    o.customer_id,
+    o.total_amount,
+    c.customer_name
+FROM `prod-env`.`main-cluster`.customer_metrics o
+JOIN `customer-env`.`crm-cluster`.customer_details c
+    ON o.customer_id = c.id
+WHERE o.total_amount > 1000;
+```
+
+## Testing Approaches
+
+### Unit Testing Framework
+```kotlin
+// Test dependencies in build.gradle.kts
+dependencies {
+    testImplementation("org.apache.flink:flink-test-utils:$flinkVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.testcontainers:kafka:1.19.1")
+    testImplementation("org.testcontainers:junit-jupiter:1.19.1")
+}
+
+// Example unit test
+@Test
+public void testOrderProcessor() throws Exception {
+    ProcessFunction<OrderEvent, OrderSummary> processor = new OrderProcessor();
+    
+    OneInputStreamOperatorTestHarness<OrderEvent, OrderSummary> testHarness = 
+        ProcessFunctionTestHarnesses.forProcessFunction(processor);
+    
+    testHarness.open();
+    testHarness.processElement(new OrderEvent("customer1", 100.0), 1000);
+    
+    assertEquals(1, testHarness.getOutput().size());
+}
+```
+
+### Integration Testing
+```java
+// Docker-based integration test
+@Test
+public void testKafkaIntegration() {
+    KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
+    kafka.start();
+    
+    // Test Flink job with real Kafka
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // Test implementation
+}
+```
+
+## Performance Considerations
+
+### Local Development Optimization
+```yaml
+# Performance settings
+taskmanager:
+  memory:
+    process:
+      size: 2g
+    network:
+      fraction: 0.1
+  numberOfTaskSlots: 4
+
+execution:
+  checkpointing:
+    interval: 60s
+    timeout: 10min
+  buffer-timeout: 100ms
+
+pipeline:
+  auto-watermark-interval: 100ms
+```
+
+### Monitoring Configuration
+```yaml
+# Metrics configuration
+metrics:
+  reporters: prom
+  reporter:
+    prom:
+      factory:
+        class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+      port: 9249
+```
+
+## Common Beginner Pitfalls and Solutions
+
+### Authentication Issues
+**Problem:** SASL authentication failures with Confluent Cloud
+**Solution:**
+```java
+// Ensure proper JAAS configuration
+props.setProperty("sasl.jaas.config", 
+    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+    "username=\"API_KEY\" password=\"API_SECRET\";");
+```
+
+### State Management Confusion
+**Problem:** Not understanding exactly-once semantics
+**Solution:**
+```java
+// Enable checkpointing for fault tolerance
+env.enableCheckpointing(60000, CheckpointingMode.EXACTLY_ONCE);
+env.getCheckpointConfig().setMinPauseBetweenCheckpoints(30000);
+```
+
+### Memory Configuration Errors
+**Problem:** Out of memory errors during execution
+**Solution:**
+```yaml
+# Proper memory allocation
+taskmanager:
+  memory:
+    process:
+      size: 2g
+    managed:
+      fraction: 0.4  # For stateful jobs
+```
+
+### Serialization Issues
+**Problem:** Slow performance due to Kryo serialization
+**Solution:**
+```java
+// Use POJO or register custom serializers
+env.getConfig().registerTypeWithKryoSerializer(MyClass.class, MySerializer.class);
+
+// Or configure in build.gradle.kts for compile-time optimization
+tasks.compileJava {
+    options.compilerArgs.addAll(listOf(
+        "-parameters", // Enable parameter names for better serialization
+        "-Xlint:unchecked"
+    ))
+}
+```
+
+## Project Dependencies
+
+## Implementation Timeline
+
+### Phase 1: Infrastructure Setup (Week 1)
+- Docker environment configuration
+- Confluent Cloud setup and authentication
+- Base project structure creation
+
+### Phase 2: Core Lessons Development (Weeks 2-3)
+- Lesson 1-3 implementation and testing
+- Basic documentation and troubleshooting guides
+
+### Phase 3: Advanced Features (Week 4)
+- Lessons 4-5 implementation
+- Performance optimization and monitoring
+
+### Phase 4: Testing and Validation (Week 5)
+- Comprehensive testing across all lessons
+- Documentation finalization
+- User acceptance testing
+
+## Success Metrics
+
+### Technical Metrics
+- **Completion Rate**: 90% of learners complete all 5 lessons
+- **Code Execution Success**: 95% successful job submissions
+- **Performance Benchmarks**: Sub-second startup times for demo applications
+
+### Educational Metrics
+- **Comprehension Assessment**: 85% pass rate on lesson assessments
+- **Practical Application**: 80% successful completion of hands-on exercises
+- **Knowledge Retention**: 75% retention rate after 30 days
+
+## Conclusion
+
+This PRD provides a comprehensive foundation for implementing an Apache Flink 2.0 demo suite that effectively teaches stream processing concepts through progressive, hands-on learning. The integration with Confluent Cloud's managed Flink service eliminates infrastructure complexity while showcasing enterprise-grade capabilities like cross-environment queries, automatic topic-to-table mapping, and serverless auto-scaling.
+
+The combination of local Flink development using Docker and Confluent Cloud integration provides learners with both foundational DataStream API knowledge and practical experience with cloud-native stream processing. The course design leverages Flink 2.0's latest features including disaggregated state management and unified stream-batch processing, while maintaining accessibility for beginners through clear learning objectives, comprehensive error handling, and extensive documentation.
+
+Key benefits of this approach:
+- **Hybrid Architecture**: Local development with cloud data services
+- **Real-world Relevance**: Enterprise patterns using managed services  
+- **Progressive Learning**: From basic concepts to advanced SQL analytics
+- **Practical Experience**: Both programmatic APIs and declarative SQL approaches
+- **Cloud-Native Skills**: Exposure to serverless stream processing concepts

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,243 @@
+# Apache Flink 2.0 Demo Suite - Improvement Tasks
+
+**Document Version:** 1.0  
+**Date:** July 15, 2025  
+**Status:** Implementation Roadmap
+
+This document provides a comprehensive, actionable checklist for implementing and improving the Apache Flink 2.0 Demo Suite based on the educational principles outlined in `plan.md` and technical requirements from `requirements.md`.
+
+## Phase 1: Foundation & Project Structure
+
+### 1.1 Core Project Setup
+- [x] Create root project structure with proper directory hierarchy
+- [x] Initialize Gradle build system with Kotlin DSL
+- [x] Configure Java 17 compatibility and Flink 2.0 dependencies
+- [x] Set up multi-module project structure for 5 lessons
+- [x] Create shared utilities module for common code
+- [x] Add essential Flink dependencies (flink-streaming-java, flink-clients, flink-connector-kafka)
+
+### 1.2 Docker Infrastructure
+- [x] Create base docker-compose.yml with Flink 2.0 cluster configuration
+- [x] Configure JobManager with Web UI access (port 8081)
+- [x] Set up TaskManager with appropriate memory allocation (2GB)
+- [x] Add volume mounts for lesson code and configuration
+- [x] Create simplified Flink configuration (flink-conf.yaml)
+- [x] Add logging configuration (log4j2.properties) for educational clarity
+
+### 1.3 Build System Configuration
+- [x] Configure Gradle shadowJar plugin for fat JAR creation
+- [x] Set up individual run tasks for each lesson
+- [x] Add dependency management for Kafka connectors
+- [x] Configure compiler options for parameter names preservation
+- [x] Create clean build and execution scripts
+- [x] Add IDE configuration files (.idea, .vscode) to gitignore
+
+## Phase 2: Lesson Implementation
+
+### 2.1 Lesson 1: DataStream API with In-Memory Data
+- [x] Create lesson01-datastream-memory module
+- [x] Implement StreamingWordCount with clear, educational code structure
+- [x] Add comprehensive inline comments explaining Flink concepts
+- [x] Create Tokenizer class with simple, understandable logic
+- [x] Configure single parallelism for learning clarity
+- [x] Add sample data generation utilities
+- [x] Create README.md with step-by-step execution guide
+- [x] Add "Try this" experimentation suggestions in code comments
+
+### 2.2 Lesson 2: Kafka Integration
+- [x] Create lesson02-kafka-consumption module
+- [x] Implement Confluent Cloud Kafka source configuration
+- [x] Add environment variable handling for API keys
+- [x] Create secure SASL_SSL authentication setup
+- [x] Implement watermark strategy for event time processing
+- [x] Add consumer lag monitoring examples
+- [x] Create troubleshooting guide for common connection issues
+- [x] Add sample data producer scripts for testing
+
+### 2.3 Lesson 3: Advanced Stream Processing
+- [x] Create lesson03-data-processing module
+- [x] Implement stateful processing with keyed streams
+- [x] Add window operations (tumbling, sliding) with clear examples
+- [x] Create custom aggregation functions with educational focus
+- [x] Implement late data handling with side outputs
+- [x] Add checkpointing configuration for fault tolerance
+- [x] Create order processing example with realistic business logic
+- [x] Add performance monitoring and debugging tips
+
+### 2.4 Lesson 4: Materialized Views
+- [x] Create lesson04-materialized-views module
+- [x] Implement Confluent Cloud Flink SQL integration (conceptual)
+- [x] Add automatic topic-to-table mapping examples
+- [x] Create materialized view creation and management code
+- [x] Implement cross-environment query capabilities
+- [x] Add persistent storage integration examples
+- [x] Create refresh strategy configuration
+- [x] Add monitoring for materialized view performance
+
+### 2.5 Lesson 5: Table API and SQL
+- [x] Create lesson05-table-api-sql module
+- [x] Implement Table API transformations with clear examples
+- [x] Add SQL query examples with window functions
+- [x] Create performance comparison between DataStream and Table API
+- [x] Implement complex analytical queries
+- [x] Add optimization settings for Table API
+- [x] Create side-by-side comparison examples
+- [x] Add best practices guide for API selection
+
+## Phase 3: Educational Enhancements
+
+### 3.1 Documentation Improvements
+- [ ] Create comprehensive setup guide (setup-guide.md)
+- [ ] Write Confluent Cloud integration guide (confluent-cloud-setup.md)
+- [ ] Add troubleshooting documentation with common issues
+- [ ] Create visual diagrams showing data flow for each lesson
+- [ ] Add before/after data examples for transformations
+- [ ] Write step-by-step execution traces
+- [ ] Create glossary of Flink terms and concepts
+- [ ] Add FAQ section with beginner questions
+
+### 3.2 Code Quality & Readability
+- [ ] Review all code for unnecessary complexity and simplify
+- [ ] Add descriptive variable names throughout codebase
+- [ ] Include "what this does" comments for each transformation
+- [ ] Remove complex try-catch blocks where not educational
+- [ ] Use simple data types (String, Integer) where appropriate
+- [ ] Add consistent code formatting and style
+- [ ] Create code review checklist for educational clarity
+- [ ] Add inline examples of expected output
+
+### 3.3 Learning Experience Optimization
+- [ ] Add "What you'll learn" sections to each lesson
+- [ ] Create hands-on experimentation suggestions
+- [ ] Add "Try changing this" comments in code
+- [ ] Include multiple test datasets for experimentation
+- [ ] Add "What happens if..." exploration questions
+- [ ] Create common mistakes and solutions guide
+- [ ] Add debugging tips specific to each lesson
+- [ ] Include success indicators for each step
+
+## Phase 4: Testing & Validation
+
+### 4.1 Basic Testing Framework
+- [ ] Create simple main() methods for direct execution
+- [ ] Add basic assertions using standard Java
+- [ ] Include expected output in code comments
+- [ ] Create validation scripts for each lesson
+- [ ] Add smoke tests for Docker environment
+- [ ] Create integration tests for Kafka connectivity
+- [ ] Add performance benchmarking for educational examples
+- [ ] Create automated lesson execution validation
+
+### 4.2 Environment Testing
+- [ ] Test complete setup on fresh Docker installation
+- [ ] Validate Confluent Cloud connectivity across regions
+- [ ] Test memory allocation and performance settings
+- [ ] Verify all lessons run successfully in sequence
+- [ ] Test with different Java versions (11, 17)
+- [ ] Validate cross-platform compatibility (Mac, Linux, Windows)
+- [ ] Create environment troubleshooting scripts
+- [ ] Add system requirements validation
+
+## Phase 5: Advanced Features & Polish
+
+### 5.1 Confluent Cloud Integration
+- [ ] Implement cross-environment query examples
+- [ ] Add Schema Registry integration with Avro
+- [ ] Create topic management automation scripts
+- [ ] Add monitoring and metrics collection
+- [ ] Implement proper error handling for cloud connectivity
+- [ ] Create backup/fallback scenarios for offline development
+- [ ] Add cost optimization tips for cloud usage
+- [ ] Create security best practices guide
+
+### 5.2 Performance & Monitoring
+- [ ] Add basic metrics collection and reporting
+- [ ] Create performance tuning examples
+- [ ] Implement simple monitoring dashboards
+- [ ] Add resource usage optimization tips
+- [ ] Create scaling examples for different workloads
+- [ ] Add memory management best practices
+- [ ] Create performance troubleshooting guide
+- [ ] Add benchmark comparison tools
+
+### 5.3 Developer Experience
+- [ ] Create IDE setup guides for IntelliJ and VS Code
+- [ ] Add debugging configuration examples
+- [ ] Create hot-reload development setup
+- [ ] Add code completion and syntax highlighting tips
+- [ ] Create development workflow documentation
+- [ ] Add Git hooks for code quality
+- [ ] Create contributor guidelines
+- [ ] Add automated formatting and linting
+
+## Phase 6: Validation & Feedback
+
+### 6.1 Educational Effectiveness Testing
+- [ ] Test all examples with beginner developers
+- [ ] Gather feedback on learning progression
+- [ ] Validate setup time is under 10 minutes
+- [ ] Ensure code clarity for beginners
+- [ ] Test hands-on experimentation features
+- [ ] Validate concept understanding through exercises
+- [ ] Create assessment quizzes for each lesson
+- [ ] Add learning outcome validation
+
+### 6.2 Technical Validation
+- [ ] Perform end-to-end testing of all lessons
+- [ ] Validate Docker environment stability
+- [ ] Test Confluent Cloud integration reliability
+- [ ] Verify performance benchmarks are met
+- [ ] Test error handling and recovery scenarios
+- [ ] Validate security configurations
+- [ ] Test backup and disaster recovery procedures
+- [ ] Create production readiness checklist
+
+## Success Criteria
+
+### Primary Goals
+- [ ] Setup time: Under 10 minutes from clone to first running example
+- [ ] Code clarity: Beginners can understand examples without external help
+- [ ] Learning progression: Each lesson builds naturally on the previous
+- [ ] Execution success: 100% of examples run successfully with provided setup
+
+### Educational Effectiveness
+- [ ] Concept clarity: Learners can explain what each code block does
+- [ ] Hands-on engagement: Learners modify and experiment with examples
+- [ ] Progression confidence: Learners feel ready for the next lesson
+- [ ] Practical understanding: Learners can apply concepts to new scenarios
+
+## Implementation Timeline
+
+### Week 1: Foundation (Phase 1)
+- [ ] Complete project structure setup
+- [ ] Implement Docker infrastructure
+- [ ] Configure build system
+
+### Week 2: Core Lessons (Phase 2.1-2.3)
+- [ ] Implement Lessons 1-3
+- [ ] Add basic documentation
+- [ ] Create initial testing framework
+
+### Week 3: Advanced Lessons (Phase 2.4-2.5)
+- [ ] Implement Lessons 4-5
+- [ ] Add Confluent Cloud integration
+- [ ] Enhance documentation
+
+### Week 4: Enhancement & Polish (Phase 3-4)
+- [ ] Improve educational features
+- [ ] Add comprehensive testing
+- [ ] Optimize developer experience
+
+### Week 5: Validation & Launch (Phase 5-6)
+- [ ] Perform end-to-end testing
+- [ ] Gather feedback and iterate
+- [ ] Finalize documentation and launch
+
+## Notes
+
+- All tasks should prioritize educational value over production complexity
+- Code examples should be immediately understandable by beginners
+- Focus on Flink concepts rather than infrastructure complexity
+- Maintain consistency across all lessons and examples
+- Regular validation with target audience (beginner developers)
+- Keep setup and execution as simple as possible

--- a/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
+++ b/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
@@ -70,7 +70,7 @@ public class KafkaConsumerExample {
         // These should be set in your .env file and loaded into the environment
         String bootstrapServers = KafkaUtils.getEnvVar(
             "CFLT_KAFKA_BROKER",
-            "your-kafka-broker:9092"
+            "localhost:9092"
         );
         String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
         String apiSecret = KafkaUtils.getEnvVar(

--- a/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
+++ b/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
@@ -60,7 +60,7 @@ public class KafkaConsumerExample {
             FlinkEnvironmentConfig.createEnvironmentWithUI();
 
         System.out.println("=== Flink Lesson 2: Kafka Integration ===");
-        System.out.println("Connecting to Confluent Cloud Kafka...");
+        System.out.println("Connecting to Kafka...");
         System.out.println();
 
         // Print Web UI access instructions
@@ -94,7 +94,7 @@ public class KafkaConsumerExample {
             )
             .build();
 
-        // Step 4: Create data st ream from Kafka source
+        // Step 4: Create data stream from Kafka source
         // This creates a continuous stream of Order objects from your Kafka topic
         DataStream<Order> kafkaStream = env.fromSource(
             kafkaSource,

--- a/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
+++ b/src/main/java/com/example/flink/lesson02/KafkaConsumerExample.java
@@ -1,8 +1,8 @@
 package com.example.flink.lesson02;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
-
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -10,12 +10,9 @@ import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import shared.data.generators.Order;
-import utils.KafkaUtils;
 import utils.FlinkEnvironmentConfig;
+import utils.KafkaUtils;
 
 /**
  * Lesson 2: Kafka Integration with Confluent Cloud (Order Processing)
@@ -57,84 +54,99 @@ import utils.FlinkEnvironmentConfig;
  */
 public class KafkaConsumerExample {
 
-  public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
+        // Step 1: Create the execution environment with Web UI enabled
+        StreamExecutionEnvironment env =
+            FlinkEnvironmentConfig.createEnvironmentWithUI();
 
-    // Step 1: Create the execution environment with Web UI enabled
-    StreamExecutionEnvironment env = FlinkEnvironmentConfig.createEnvironmentWithUI();
+        System.out.println("=== Flink Lesson 2: Kafka Integration ===");
+        System.out.println("Connecting to Confluent Cloud Kafka...");
+        System.out.println();
 
-    System.out.println("=== Flink Lesson 2: Kafka Integration ===");
-    System.out.println("Connecting to Confluent Cloud Kafka...");
-    System.out.println();
-    
-    // Print Web UI access instructions
-    FlinkEnvironmentConfig.printWebUIInstructions();
+        // Print Web UI access instructions
+        FlinkEnvironmentConfig.printWebUIInstructions();
 
-    // Step 2: Load Confluent Cloud configuration from environment variables
-    // These should be set in your .env file and loaded into the environment
-    String bootstrapServers = KafkaUtils.getEnvVar("CNFL_KAFKA_BROKER", "your-kafka-broker:9092");
-    String apiKey = KafkaUtils.getEnvVar("CNFL_KC_API_KEY", "your-api-key");
-    String apiSecret = KafkaUtils.getEnvVar("CNFL_KC_API_SECRET", "your-api-secret");
-    String topicName = "orders"; // You can change this to any topic in your cluster
+        // Step 2: Load Confluent Cloud configuration from environment variables
+        // These should be set in your .env file and loaded into the environment
+        String bootstrapServers = KafkaUtils.getEnvVar(
+            "CFLT_KAFKA_BROKER",
+            "your-kafka-broker:9092"
+        );
+        String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
+        String apiSecret = KafkaUtils.getEnvVar(
+            "CFLT_KC_API_SECRET",
+            "your-api-secret"
+        );
+        String topicName = "orders"; // You can change this to any topic in your cluster
 
-    System.out.println("Bootstrap servers: " + bootstrapServers);
-    System.out.println("Using topic: " + topicName);
+        System.out.println("Bootstrap servers: " + bootstrapServers);
+        System.out.println("Using topic: " + topicName);
 
-    // Step 3: Configure Kafka source with Confluent Cloud settings
-    KafkaSource<Order> kafkaSource = KafkaSource.<Order>builder()
-        .setBootstrapServers(bootstrapServers)
-        .setTopics(topicName)
-        .setGroupId("flink-lesson02-consumer-group")
-        .setStartingOffsets(OffsetsInitializer.latest()) // Start from latest messages
-        .setValueOnlyDeserializer(new OrderJsonDeserializer())
-        .setProperties(KafkaUtils.createConsumerKafkaProperties(apiKey, apiSecret))
-        .build();
+        // Step 3: Configure Kafka source with Confluent Cloud settings
+        KafkaSource<Order> kafkaSource = KafkaSource.<Order>builder()
+            .setBootstrapServers(bootstrapServers)
+            .setTopics(topicName)
+            .setGroupId("flink-lesson02-consumer-group")
+            .setStartingOffsets(OffsetsInitializer.latest()) // Start from latest messages
+            .setValueOnlyDeserializer(new OrderJsonDeserializer())
+            .setProperties(
+                KafkaUtils.createConsumerKafkaProperties(apiKey, apiSecret)
+            )
+            .build();
 
-    // Step 4: Create data st ream from Kafka source
-    // This creates a continuous stream of Order objects from your Kafka topic
-    DataStream<Order> kafkaStream = env
-        .fromSource(
+        // Step 4: Create data st ream from Kafka source
+        // This creates a continuous stream of Order objects from your Kafka topic
+        DataStream<Order> kafkaStream = env.fromSource(
             kafkaSource,
-            WatermarkStrategy.<Order>forBoundedOutOfOrderness(Duration.ofSeconds(5))
-                .withTimestampAssigner((order, timestamp) -> order.timestamp),
+            WatermarkStrategy.<Order>forBoundedOutOfOrderness(
+                Duration.ofSeconds(5)
+            ).withTimestampAssigner((order, timestamp) -> order.timestamp),
             "Kafka Source"
         );
 
-    // Step 5: Process the stream
-    // For this lesson, we'll process each Order object and extract useful information
-    // In real applications, you'd apply transformations, aggregations, etc.
-    kafkaStream
-        .map(order -> {
-          // Add processing timestamp for educational purposes
-          long processingTime = System.currentTimeMillis();
-          String processedOrder = String.format("[%d] Order processed: %s (Customer: %s, Amount: $%.2f, Category: %s)",
-                                                processingTime, order.orderId, order.customerId, order.amount, order.category);
-          System.out.println("Processing order: " + order);
-          return processedOrder;
-        })
-        .print("Processed Orders");
+        // Step 5: Process the stream
+        // For this lesson, we'll process each Order object and extract useful information
+        // In real applications, you'd apply transformations, aggregations, etc.
+        kafkaStream
+            .map(order -> {
+                // Add processing timestamp for educational purposes
+                long processingTime = System.currentTimeMillis();
+                String processedOrder = String.format(
+                    "[%d] Order processed: %s (Customer: %s, Amount: $%.2f, Category: %s)",
+                    processingTime,
+                    order.orderId,
+                    order.customerId,
+                    order.amount,
+                    order.category
+                );
+                System.out.println("Processing order: " + order);
+                return processedOrder;
+            })
+            .print("Processed Orders");
 
-    // Step 6: Execute the program
-    System.out.println("Starting Kafka consumer... Press Ctrl+C to stop.");
-    env.execute("Lesson 2: Kafka Consumer with Confluent Cloud");
-  }
-
-
-  /**
-   * JSON Deserializer for Order objects from Kafka
-   * Handles conversion from JSON strings to Order objects
-   */
-  public static class OrderJsonDeserializer extends AbstractDeserializationSchema<Order> {
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    @Override
-    public Order deserialize(byte[] message) throws IOException {
-      return objectMapper.readValue(message, Order.class);
+        // Step 6: Execute the program
+        System.out.println("Starting Kafka consumer... Press Ctrl+C to stop.");
+        env.execute("Lesson 2: Kafka Consumer with Confluent Cloud");
     }
 
-    @Override
-    public TypeInformation<Order> getProducedType() {
-      return TypeInformation.of(Order.class);
+    /**
+     * JSON Deserializer for Order objects from Kafka
+     * Handles conversion from JSON strings to Order objects
+     */
+    public static class OrderJsonDeserializer
+        extends AbstractDeserializationSchema<Order>
+    {
+
+        private static final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Override
+        public Order deserialize(byte[] message) throws IOException {
+            return objectMapper.readValue(message, Order.class);
+        }
+
+        @Override
+        public TypeInformation<Order> getProducedType() {
+            return TypeInformation.of(Order.class);
+        }
     }
-  }
 }

--- a/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
+++ b/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
@@ -63,7 +63,7 @@ public abstract class BaseOrderProcessingJob {
         // Load Confluent Cloud configuration from environment variables
         String bootstrapServers = KafkaUtils.getEnvVar(
             "CFLT_KAFKA_BROKER",
-            "your-kafka-broker:9092"
+            "localhost:9092"
         );
         String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
         String apiSecret = KafkaUtils.getEnvVar(

--- a/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
+++ b/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
@@ -57,7 +57,7 @@ public abstract class BaseOrderProcessingJob {
         String consumerGroupId
     ) {
         System.out.println(
-            "Connecting to Confluent Cloud Kafka for order data..."
+            "Connecting to Kafka for order data..."
         );
 
         // Load Confluent Cloud configuration from environment variables

--- a/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
+++ b/src/main/java/com/example/flink/lesson03/BaseOrderProcessingJob.java
@@ -1,8 +1,8 @@
 package com.example.flink.lesson03;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
-
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -10,20 +10,17 @@ import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import shared.data.generators.Order;
-import utils.KafkaUtils;
 import utils.FlinkEnvironmentConfig;
+import utils.KafkaUtils;
 
 /**
  * Base class for Order Processing Jobs
- * <p> 
+ * <p>
  * This class provides common Kafka integration setup and utilities that are shared
  * across all order processing jobs. It eliminates code duplication while allowing
  * each job to focus on its specific processing logic.
- * <p> 
+ * <p>
  * Educational Benefits:
  * - Demonstrates proper code organization and reuse
  * - Shows how to create base classes for common functionality
@@ -44,24 +41,35 @@ public abstract class BaseOrderProcessingJob {
 
     /**
      * Creates a Kafka source for Order objects with Confluent Cloud integration.
-     * <p> 
+     * <p>
      * This method handles all the common Kafka configuration including:
-     * <p> 
+     * <p>
      * - Environment variable loading
-     * <p> 
+     * <p>
      * - Confluent Cloud authentication
-     * <p> 
+     * <p>
      * - JSON deserialization
-     * <p> 
+     * <p>
      * - Consumer group configuration
      */
-    protected static DataStream<Order> createOrderStream(StreamExecutionEnvironment env, String consumerGroupId) {
-        System.out.println("Connecting to Confluent Cloud Kafka for order data...");
+    protected static DataStream<Order> createOrderStream(
+        StreamExecutionEnvironment env,
+        String consumerGroupId
+    ) {
+        System.out.println(
+            "Connecting to Confluent Cloud Kafka for order data..."
+        );
 
         // Load Confluent Cloud configuration from environment variables
-        String bootstrapServers = KafkaUtils.getEnvVar("CNFL_KAFKA_BROKER", "your-kafka-broker:9092");
-        String apiKey = KafkaUtils.getEnvVar("CNFL_KC_API_KEY", "your-api-key");
-        String apiSecret = KafkaUtils.getEnvVar("CNFL_KC_API_SECRET", "your-api-secret");
+        String bootstrapServers = KafkaUtils.getEnvVar(
+            "CFLT_KAFKA_BROKER",
+            "your-kafka-broker:9092"
+        );
+        String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
+        String apiSecret = KafkaUtils.getEnvVar(
+            "CFLT_KC_API_SECRET",
+            "your-api-secret"
+        );
 
         System.out.println("Bootstrap servers: " + bootstrapServers);
         System.out.println("Using topic: " + TOPIC_NAME);
@@ -74,14 +82,17 @@ public abstract class BaseOrderProcessingJob {
             .setGroupId(consumerGroupId)
             .setStartingOffsets(OffsetsInitializer.latest()) // Start from latest messages for real-time processing
             .setValueOnlyDeserializer(new OrderJsonDeserializer())
-            .setProperties(KafkaUtils.createConsumerKafkaProperties(apiKey, apiSecret))
+            .setProperties(
+                KafkaUtils.createConsumerKafkaProperties(apiKey, apiSecret)
+            )
             .build();
 
         // Create data stream from Kafka source
         return env.fromSource(
             kafkaSource,
-            WatermarkStrategy.<Order>forBoundedOutOfOrderness(Duration.ofSeconds(5))
-                .withTimestampAssigner((order, timestamp) -> order.timestamp),
+            WatermarkStrategy.<Order>forBoundedOutOfOrderness(
+                Duration.ofSeconds(5)
+            ).withTimestampAssigner((order, timestamp) -> order.timestamp),
             "Kafka Order Source"
         );
     }
@@ -93,7 +104,7 @@ public abstract class BaseOrderProcessingJob {
         System.out.println("=== " + jobName + " ===");
         System.out.println(description);
         System.out.println();
-        
+
         // Print Web UI access instructions
         FlinkEnvironmentConfig.printWebUIInstructions();
     }
@@ -101,7 +112,10 @@ public abstract class BaseOrderProcessingJob {
     /**
      * Executes the job with proper error handling and educational messaging
      */
-    protected static void executeJob(StreamExecutionEnvironment env, String jobName) throws Exception {
+    protected static void executeJob(
+        StreamExecutionEnvironment env,
+        String jobName
+    ) throws Exception {
         System.out.println("Starting " + jobName + "... Press Ctrl+C to stop.");
         env.execute(jobName);
     }
@@ -110,7 +124,9 @@ public abstract class BaseOrderProcessingJob {
      * JSON Deserializer for Order objects from Kafka
      * Handles conversion from JSON strings to Order objects
      */
-    public static class OrderJsonDeserializer extends AbstractDeserializationSchema<Order> {
+    public static class OrderJsonDeserializer
+        extends AbstractDeserializationSchema<Order>
+    {
 
         private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -121,8 +137,13 @@ public abstract class BaseOrderProcessingJob {
                 Order order = objectMapper.readValue(message, Order.class);
                 return order;
             } catch (Exception e) {
-                System.err.println("[ERROR] Failed to deserialize message: " + new String(message));
-                System.err.println("[ERROR] Deserialization error: " + e.getMessage());
+                System.err.println(
+                    "[ERROR] Failed to deserialize message: " +
+                        new String(message)
+                );
+                System.err.println(
+                    "[ERROR] Deserialization error: " + e.getMessage()
+                );
                 e.printStackTrace();
                 throw e;
             }

--- a/src/main/java/com/example/flink/lesson04/MaterializedViewExample.java
+++ b/src/main/java/com/example/flink/lesson04/MaterializedViewExample.java
@@ -1,0 +1,430 @@
+package com.example.flink.lesson04;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import utils.FlinkEnvironmentConfig;
+
+/**
+ * Lesson 4: Materialized Views with Confluent Cloud (Conceptual)
+ * <p>
+ * This lesson explains the concepts of materialized views using Apache Flink's Table API
+ * and SQL with Confluent Cloud integration. Since Flink 2.0 is not yet released, this
+ * lesson focuses on teaching the concepts and provides code examples that will work
+ * when the Table API dependencies become available.
+ * <p>
+ * What you'll learn:
+ * - Understanding materialized views and their benefits
+ * - How Table API bridges DataStream and SQL worlds
+ * - Creating tables from Kafka topics (topic-to-table mapping)
+ * - Building materialized views with SQL queries
+ * - Managing view refresh strategies and persistence
+ * - Monitoring materialized view performance
+ * - Cross-environment query capabilities
+ * - Integration patterns with Confluent Cloud Flink SQL
+ * <p>
+ * Key Concepts:
+ * <p> 
+ * 1. MATERIALIZED VIEWS
+ *    - Pre-computed query results stored for fast access
+ *    - Automatically updated as source data changes
+ *    - Trade storage space for query performance
+ *    - Essential for real-time analytics dashboards
+ * <p>
+ * 2. TABLE API INTEGRATION
+ *    - StreamTableEnvironment bridges DataStream and Table APIs
+ *    - SQL DDL creates tables from Kafka topics
+ *    - Views defined using standard SQL syntax
+ *    - Seamless integration with streaming data
+ * <p>
+ * 3. CONFLUENT CLOUD BENEFITS
+ *    - Managed Kafka infrastructure
+ *    - Built-in Flink SQL capabilities
+ *    - Cross-environment data access
+ *    - Automatic scaling and maintenance
+ * <p>
+ * Business Scenario:
+ * We're creating materialized views for an e-commerce analytics platform:
+ * - Real-time customer spending summaries
+ * - Product category performance metrics
+ * - Hourly sales dashboards
+ * - Customer segmentation views
+ * - Inventory level monitoring
+ * <p>
+ * Expected Output (when Table API is available):
+ * Creating Kafka source table: orders
+ * Creating materialized view: customer_spending_summary
+ * Creating materialized view: hourly_sales_metrics
+ * Creating materialized view: product_category_performance
+ * View Results - Customer Spending:
+ * +-------------+-------------+-------------+
+ * | customer_id | total_spent | order_count |
+ * +-------------+-------------+-------------+
+ * | customer_001|      1247.89|           15|
+ * | customer_002|       892.34|           12|
+ * +-------------+-------------+-------------+
+ * <p>
+ * Try this (when dependencies are available):
+ * 1. Modify the SQL queries to add new aggregation metrics
+ * 2. Create additional materialized views for different business needs
+ * 3. Experiment with different refresh strategies
+ * 4. Add time-based windowing to the views
+ * 5. Create views that join multiple Kafka topics
+ */
+public class MaterializedViewExample {
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("=== Flink Lesson 4: Materialized Views (Conceptual) ===");
+        System.out.println("This lesson explains materialized view concepts for Flink 2.0");
+        System.out.println();
+
+        // Step 1: Create streaming execution environment with Web UI enabled
+        StreamExecutionEnvironment env = FlinkEnvironmentConfig.createEnvironmentWithUI();
+        
+        // Print Web UI access instructions
+        FlinkEnvironmentConfig.printWebUIInstructions();
+        
+        // Configure for educational clarity
+        env.setParallelism(1);
+        env.enableCheckpointing(60000);
+
+        System.out.println("✓ Streaming environment created");
+        System.out.println("✓ Checkpointing enabled for fault tolerance");
+
+        // Step 2: Explain Table API Environment Setup
+        explainTableAPISetup();
+
+        // Step 3: Demonstrate Kafka Source Table Creation
+        demonstrateKafkaSourceTable();
+
+        // Step 4: Show Materialized View Examples
+        showMaterializedViewExamples();
+
+        // Step 5: Explain View Querying
+        explainViewQuerying();
+
+        // Step 6: Discuss Continuous Maintenance
+        discussContinuousMaintenance();
+
+        // Step 7: Provide Implementation Roadmap
+        provideImplementationRoadmap();
+
+        System.out.println("\n=== Lesson Complete ===");
+        System.out.println("When Flink 2.0 is released, you can:");
+        System.out.println("1. Uncomment Table API dependencies in build.gradle.kts");
+        System.out.println("2. Replace this conceptual code with actual Table API implementation");
+        System.out.println("3. Run real materialized views with Confluent Cloud");
+        
+        // Note: This is a conceptual lesson - no actual streaming execution needed
+        System.out.println("\nThis conceptual lesson is complete!");
+        System.out.println("Ready to implement with real Confluent Cloud Flink SQL when available.");
+    }
+
+    /**
+     * Explains how to set up Table API environment
+     */
+    private static void explainTableAPISetup() {
+        System.out.println("\n=== Step 2: Table API Environment Setup ===");
+        System.out.println("When Table API dependencies are available, you would:");
+        System.out.println();
+        
+        System.out.println("// Import required classes:");
+        System.out.println("import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;");
+        System.out.println("import org.apache.flink.table.api.Table;");
+        System.out.println();
+        
+        System.out.println("// Create Table Environment:");
+        System.out.println("StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);");
+        System.out.println();
+        
+        System.out.println("Key Benefits:");
+        System.out.println("- Bridges DataStream API and SQL");
+        System.out.println("- Enables SQL queries on streaming data");
+        System.out.println("- Supports complex analytical operations");
+        System.out.println("- Integrates with Confluent Cloud seamlessly");
+    }
+
+    /**
+     * Demonstrates Kafka source table creation
+     */
+    private static void demonstrateKafkaSourceTable() {
+        System.out.println("\n=== Step 3: Kafka Source Table Creation ===");
+        System.out.println("Creating a table from Kafka topic with Confluent Cloud:");
+        System.out.println();
+        
+        String exampleSQL = """
+            CREATE TABLE orders (
+                orderId STRING,
+                customerId STRING,
+                amount DECIMAL(10,2),
+                `timestamp` BIGINT,
+                category STRING,
+                order_time AS TO_TIMESTAMP_LTZ(`timestamp`, 3),
+                WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
+            ) WITH (
+                'connector' = 'kafka',
+                'topic' = 'orders',
+                'properties.bootstrap.servers' = 'your-confluent-cloud-broker',
+                'properties.security.protocol' = 'SASL_SSL',
+                'properties.sasl.mechanism' = 'PLAIN',
+                'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username="<api-key>" password="<api-secret>";',
+                'format' = 'json',
+                'scan.startup.mode' = 'latest-offset'
+            )
+            """;
+        
+        System.out.println("Example DDL:");
+        System.out.println(exampleSQL);
+        
+        System.out.println("Key Features:");
+        System.out.println("- Maps Kafka topic to SQL table");
+        System.out.println("- Supports watermarks for event time");
+        System.out.println("- Handles Confluent Cloud authentication");
+        System.out.println("- Configurable startup modes");
+    }
+
+    /**
+     * Shows examples of materialized views
+     */
+    private static void showMaterializedViewExamples() {
+        System.out.println("\n=== Step 4: Materialized View Examples ===");
+        System.out.println("Individual .flink.sql files have been created in src/main/resources/lesson04/ for each use case:");
+        System.out.println();
+        
+        // Customer Spending Summary
+        System.out.println("1. Customer Spending Summary View (customer-spending-summary.flink.sql):");
+        System.out.println("   Use case: Customer analytics, loyalty programs, personalized marketing");
+        String customerSpendingSQL = """
+            CREATE VIEW customer_spending_summary AS
+            SELECT 
+                customerId,
+                SUM(amount) as total_spent,
+                COUNT(*) as order_count,
+                AVG(amount) as avg_order_value,
+                MAX(amount) as max_order_value,
+                COUNT(DISTINCT category) as categories_purchased
+            FROM orders
+            GROUP BY customerId
+            """;
+        System.out.println(customerSpendingSQL);
+        
+        // Hourly Sales Metrics
+        System.out.println("2. Hourly Sales Metrics View (hourly-sales-metrics.flink.sql):");
+        System.out.println("   Use case: Real-time dashboards, performance monitoring, trend analysis");
+        String hourlySalesSQL = """
+            CREATE VIEW hourly_sales_metrics AS
+            SELECT 
+                window_start as hour_start,
+                window_end as hour_end,
+                COUNT(*) as total_orders,
+                SUM(amount) as total_revenue,
+                AVG(amount) as avg_order_value,
+                COUNT(DISTINCT customerId) as unique_customers,
+                COUNT(DISTINCT category) as categories_sold,
+                MAX(amount) as max_order_amount,
+                MIN(amount) as min_order_amount
+            FROM TUMBLE(TABLE orders, DESCRIPTOR(order_time), INTERVAL '1' HOUR)
+            GROUP BY window_start, window_end
+            """;
+        System.out.println(hourlySalesSQL);
+        
+        // Customer Segmentation
+        System.out.println("3. Customer Segmentation View (customer-segmentation.flink.sql):");
+        System.out.println("   Use case: Marketing campaigns, customer retention, personalized experiences");
+        String segmentationSQL = """
+            CREATE VIEW customer_segmentation AS
+            SELECT 
+                customerId,
+                SUM(amount) as total_spent,
+                COUNT(*) as order_count,
+                AVG(amount) as avg_order_value,
+                COUNT(DISTINCT category) as categories_purchased,
+                CASE 
+                    WHEN SUM(amount) >= 1000 AND COUNT(*) >= 10 THEN 'VIP'
+                    WHEN SUM(amount) >= 500 OR COUNT(*) >= 5 THEN 'Premium'
+                    WHEN SUM(amount) >= 100 OR COUNT(*) >= 2 THEN 'Regular'
+                    ELSE 'New'
+                END as customer_segment,
+                CASE
+                    WHEN COUNT(DISTINCT category) >= 4 THEN 'Diverse'
+                    WHEN COUNT(DISTINCT category) >= 2 THEN 'Multi-Category'
+                    ELSE 'Single-Category'
+                END as purchase_behavior
+            FROM orders
+            GROUP BY customerId
+            """;
+        System.out.println(segmentationSQL);
+        
+        // Reference to additional SQL files
+        System.out.println("4. Category Performance Analysis (category-performance.flink.sql):");
+        System.out.println("   Use case: Inventory management, product strategy, sales optimization");
+        
+        System.out.println("Benefits of Materialized Views:");
+        System.out.println("- Pre-computed results for fast queries");
+        System.out.println("- Automatically updated as data changes");
+        System.out.println("- Support complex aggregations and joins");
+        System.out.println("- Enable real-time analytics dashboards");
+        
+        System.out.println("\n=== Advanced: Materialized Tables with Freshness ===");
+        System.out.println("For production use cases, consider MATERIALIZED TABLE with freshness guarantees:");
+        String materializedTableSQL = """
+            CREATE MATERIALIZED TABLE customer_spending_materialized
+                FRESHNESS = INTERVAL '30' SECOND
+                AS SELECT 
+                    customerId,
+                    SUM(amount) as total_spent,
+                    COUNT(*) as order_count,
+                    AVG(amount) as avg_order_value
+                FROM orders
+                GROUP BY customerId
+            """;
+        System.out.println(materializedTableSQL);
+        System.out.println("Key Benefits of MATERIALIZED TABLE:");
+        System.out.println("- Guaranteed freshness with FRESHNESS parameter");
+        System.out.println("- Automatic refresh based on data changes");
+        System.out.println("- Better performance for frequently accessed data");
+        System.out.println("- Ideal for real-time dashboards and analytics");
+    }
+
+    /**
+     * Explains how to query materialized views
+     */
+    private static void explainViewQuerying() {
+        System.out.println("\n=== Step 5: Querying Materialized Views ===");
+        System.out.println("Once views are created, you can query them like regular tables:");
+        System.out.println();
+        
+        System.out.println("// Query customer spending with Confluent Cloud syntax");
+        System.out.println("Table result = tableEnv.sqlQuery(\"SELECT * FROM customer_spending_summary ORDER BY total_spent DESC LIMIT 10\");");
+        System.out.println("result.execute().print();");
+        System.out.println();
+        
+        System.out.println("// Query recent hourly metrics");
+        System.out.println("Table hourly = tableEnv.sqlQuery(\"SELECT * FROM hourly_sales_metrics ORDER BY hour_start DESC LIMIT 5\");");
+        System.out.println("hourly.execute().print();");
+        System.out.println();
+        
+        System.out.println("// Complex analytical queries with joins");
+        System.out.println("Table analysis = tableEnv.sqlQuery(\"\"\"");
+        System.out.println("    SELECT ");
+        System.out.println("        cs.customer_segment,");
+        System.out.println("        cs.purchase_behavior,");
+        System.out.println("        COUNT(*) as customer_count,");
+        System.out.println("        AVG(cs.total_spent) as avg_spending,");
+        System.out.println("        AVG(cs.categories_purchased) as avg_categories");
+        System.out.println("    FROM customer_segmentation cs");
+        System.out.println("    GROUP BY cs.customer_segment, cs.purchase_behavior");
+        System.out.println("    ORDER BY avg_spending DESC");
+        System.out.println("\"\"\");");
+        System.out.println();
+        
+        System.out.println("// Real-time category performance analysis");
+        System.out.println("Table categoryPerf = tableEnv.sqlQuery(\"\"\"");
+        System.out.println("    SELECT ");
+        System.out.println("        category,");
+        System.out.println("        COUNT(*) as order_count,");
+        System.out.println("        SUM(amount) as total_revenue,");
+        System.out.println("        AVG(amount) as avg_order_value");
+        System.out.println("    FROM orders");
+        System.out.println("    WHERE order_time >= CURRENT_TIMESTAMP - INTERVAL '1' DAY");
+        System.out.println("    GROUP BY category");
+        System.out.println("    ORDER BY total_revenue DESC");
+        System.out.println("\"\"\");");
+        
+        System.out.println("\nConfluent Cloud Query Capabilities:");
+        System.out.println("- Standard SQL syntax with Flink extensions");
+        System.out.println("- Joins between multiple views and tables");
+        System.out.println("- Window functions and time-based analytics");
+        System.out.println("- Real-time continuous queries");
+        System.out.println("- Cross-environment data access");
+        System.out.println("- Built-in functions for stream processing");
+    }
+
+    /**
+     * Discusses continuous view maintenance
+     */
+    private static void discussContinuousMaintenance() {
+        System.out.println("\n=== Step 6: Continuous View Maintenance ===");
+        System.out.println("Confluent Cloud automatically maintains materialized views:");
+        System.out.println();
+        
+        System.out.println("Automatic Updates:");
+        System.out.println("- Views update as new data arrives in Kafka topics");
+        System.out.println("- Incremental computation for efficiency");
+        System.out.println("- Consistent results across all queries");
+        System.out.println("- Built-in fault tolerance and recovery");
+        System.out.println("- Automatic scaling based on workload");
+        System.out.println();
+        
+        System.out.println("Confluent Cloud Benefits:");
+        System.out.println("- Managed infrastructure - no cluster management");
+        System.out.println("- Automatic resource scaling");
+        System.out.println("- Built-in monitoring and alerting");
+        System.out.println("- Cross-region data replication");
+        System.out.println("- Enterprise security and compliance");
+        System.out.println();
+        
+        System.out.println("Performance Optimization:");
+        System.out.println("- Intelligent partitioning strategies");
+        System.out.println("- Optimized state storage");
+        System.out.println("- Query result caching");
+        System.out.println("- Automatic resource allocation");
+        System.out.println("- Real-time performance metrics");
+        System.out.println();
+        
+        System.out.println("Production Best Practices:");
+        System.out.println("- Use appropriate watermark strategies");
+        System.out.println("- Monitor view refresh latency");
+        System.out.println("- Set up proper alerting rules");
+        System.out.println("- Regular performance reviews");
+        System.out.println("- Implement proper access controls");
+    }
+
+    /**
+     * Provides implementation roadmap for when dependencies are available
+     */
+    private static void provideImplementationRoadmap() {
+        System.out.println("\n=== Step 7: Implementation Roadmap ===");
+        System.out.println("Implementation approaches for Confluent Cloud Flink SQL:");
+        System.out.println();
+        
+        System.out.println("Option 1: Confluent Cloud Console (Recommended for Learning)");
+        System.out.println("   - Use browser-based Flink SQL workspace");
+        System.out.println("   - Create tables directly with DDL statements");
+        System.out.println("   - Build and test materialized views interactively");
+        System.out.println("   - Monitor performance in real-time");
+        System.out.println();
+        
+        System.out.println("Option 2: Flink SQL Shell (CLI-based)");
+        System.out.println("   - Use confluent flink shell command");
+        System.out.println("   - Execute SQL statements from command line");
+        System.out.println("   - Suitable for scripted deployments");
+        System.out.println();
+        
+        System.out.println("Option 3: Local Flink 2.0 (When Available)");
+        System.out.println("   - Uncomment Table API dependencies in build.gradle.kts");
+        System.out.println("   - Add flink-table-api-java-bridge:2.0.0");
+        System.out.println("   - Add flink-table-planner:2.0.0");
+        System.out.println("   - Use actual Order schema: orderId, customerId, amount, timestamp, category");
+        System.out.println();
+        
+        System.out.println("Implementation Steps:");
+        System.out.println("   1. Set up Confluent Cloud environment and API keys");
+        System.out.println("   2. Create 'orders' topic with proper schema registry");
+        System.out.println("   3. Use OrderDataGenerator to populate test data");
+        System.out.println("   4. Create source table with correct field mapping:");
+        System.out.println("      - orderId STRING, customerId STRING, amount DECIMAL(10,2)");
+        System.out.println("      - timestamp BIGINT, category STRING");
+        System.out.println("      - Computed column: order_time AS TO_TIMESTAMP_LTZ(timestamp, 3)");
+        System.out.println("   5. Deploy materialized views using provided SQL examples");
+        System.out.println("   6. Test queries and monitor performance");
+        System.out.println();
+        
+        System.out.println("Production Considerations:");
+        System.out.println("   - Use proper RBAC and API key management");
+        System.out.println("   - Configure appropriate compute pools");
+        System.out.println("   - Set up monitoring and alerting");
+        System.out.println("   - Implement proper error handling");
+        System.out.println("   - Document view dependencies and refresh patterns");
+    }
+}

--- a/src/main/java/com/example/flink/lesson04/MaterializedViewExample.java
+++ b/src/main/java/com/example/flink/lesson04/MaterializedViewExample.java
@@ -1,430 +1,177 @@
 package com.example.flink.lesson04;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
+import shared.data.generators.Order;
 import utils.FlinkEnvironmentConfig;
 
+import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
+import static shared.data.generators.OrderDataGenerator.createBoundedSource;
+
 /**
- * Lesson 4: Materialized Views with Confluent Cloud (Conceptual)
+ * Lesson 4: Materialized Views with Flink SQL
  * <p>
- * This lesson explains the concepts of materialized views using Apache Flink's Table API
- * and SQL with Confluent Cloud integration. Since Flink 2.0 is not yet released, this
- * lesson focuses on teaching the concepts and provides code examples that will work
- * when the Table API dependencies become available.
+ * This lesson demonstrates materialized views using Apache Flink's Table API and SQL.
+ * A materialized view is a query whose results are continuously maintained as new data
+ * arrives — exactly what a streaming {@code CREATE VIEW} over an unbounded table gives you.
+ * <p>
+ * Unlike Lesson 5 (which builds the same use cases with the programmatic Table API),
+ * this lesson uses raw SQL DDL ({@code CREATE VIEW ... AS SELECT ...}) so you can see the
+ * SQL-first authoring style used by Confluent Cloud Flink SQL.
+ * <p>
+ * It runs against an in-memory bounded order source so you can execute it locally and watch
+ * the job in the Flink Web UI at http://localhost:8081. The same SQL runs unchanged against a
+ * Kafka-backed {@code orders} table on Confluent Cloud (see the DDL printed at startup and the
+ * {@code .flink.sql} files under {@code src/main/resources/lesson04/}).
  * <p>
  * What you'll learn:
- * - Understanding materialized views and their benefits
- * - How Table API bridges DataStream and SQL worlds
- * - Creating tables from Kafka topics (topic-to-table mapping)
- * - Building materialized views with SQL queries
- * - Managing view refresh strategies and persistence
- * - Monitoring materialized view performance
- * - Cross-environment query capabilities
- * - Integration patterns with Confluent Cloud Flink SQL
+ * - Bridging DataStream and SQL with {@link StreamTableEnvironment}
+ * - Authoring materialized views with {@code CREATE VIEW}
+ * - Customer spending summaries, segmentation, and category performance
+ * - How the same SQL maps to a Kafka topic-to-table definition on Confluent Cloud
  * <p>
- * Key Concepts:
- * <p> 
- * 1. MATERIALIZED VIEWS
- *    - Pre-computed query results stored for fast access
- *    - Automatically updated as source data changes
- *    - Trade storage space for query performance
- *    - Essential for real-time analytics dashboards
+ * The materialized views executed below:
+ * - customer_spending_summary  (customer-spending-summary.flink.sql)
+ * - customer_segmentation      (customer-segmentation.flink.sql)
+ * - category_performance       (category-performance.flink.sql)
  * <p>
- * 2. TABLE API INTEGRATION
- *    - StreamTableEnvironment bridges DataStream and Table APIs
- *    - SQL DDL creates tables from Kafka topics
- *    - Views defined using standard SQL syntax
- *    - Seamless integration with streaming data
+ * Time-windowed views (hourly-sales-metrics, top-performers-leaderboard) require an event-time
+ * attribute and watermark on the source table; see those {@code .flink.sql} files and Lesson 5's
+ * {@code HourlySalesMetrics} for the windowed variant.
  * <p>
- * 3. CONFLUENT CLOUD BENEFITS
- *    - Managed Kafka infrastructure
- *    - Built-in Flink SQL capabilities
- *    - Cross-environment data access
- *    - Automatic scaling and maintenance
- * <p>
- * Business Scenario:
- * We're creating materialized views for an e-commerce analytics platform:
- * - Real-time customer spending summaries
- * - Product category performance metrics
- * - Hourly sales dashboards
- * - Customer segmentation views
- * - Inventory level monitoring
- * <p>
- * Expected Output (when Table API is available):
- * Creating Kafka source table: orders
- * Creating materialized view: customer_spending_summary
- * Creating materialized view: hourly_sales_metrics
- * Creating materialized view: product_category_performance
- * View Results - Customer Spending:
- * +-------------+-------------+-------------+
- * | customer_id | total_spent | order_count |
- * +-------------+-------------+-------------+
- * | customer_001|      1247.89|           15|
- * | customer_002|       892.34|           12|
- * +-------------+-------------+-------------+
- * <p>
- * Try this (when dependencies are available):
- * 1. Modify the SQL queries to add new aggregation metrics
- * 2. Create additional materialized views for different business needs
- * 3. Experiment with different refresh strategies
- * 4. Add time-based windowing to the views
- * 5. Create views that join multiple Kafka topics
+ * Try this:
+ * 1. Add new aggregation metrics to a view (e.g. MIN/MAX amount)
+ * 2. Adjust the segmentation thresholds and re-run
+ * 3. Point the {@code orders} table at a Kafka topic using the DDL printed at startup
  */
 public class MaterializedViewExample {
 
     public static void main(String[] args) throws Exception {
 
-        System.out.println("=== Flink Lesson 4: Materialized Views (Conceptual) ===");
-        System.out.println("This lesson explains materialized view concepts for Flink 2.0");
-        System.out.println();
+        System.out.println("=== Flink Lesson 4: Materialized Views with Flink SQL ===");
+        System.out.println("Authoring materialized views with CREATE VIEW over a streaming table\n");
 
-        // Step 1: Create streaming execution environment with Web UI enabled
+        // Step 1: Create a streaming execution environment with the Web UI enabled
         StreamExecutionEnvironment env = FlinkEnvironmentConfig.createEnvironmentWithUI();
-        
-        // Print Web UI access instructions
         FlinkEnvironmentConfig.printWebUIInstructions();
-        
-        // Configure for educational clarity
-        env.setParallelism(1);
-        env.enableCheckpointing(60000);
+        System.out.println("✓ Streaming environment created (Web UI on http://localhost:8081)\n");
 
-        System.out.println("✓ Streaming environment created");
-        System.out.println("✓ Checkpointing enabled for fault tolerance");
+        // Step 2: Create the Table Environment that bridges DataStream and SQL
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+        System.out.println("✓ Table environment created\n");
 
-        // Step 2: Explain Table API Environment Setup
-        explainTableAPISetup();
+        // Step 3: Register an in-memory bounded order source as the 'orders' table.
+        //         On Confluent Cloud this 'orders' table would instead be a Kafka topic
+        //         (see the DDL below); the materialized-view SQL stays identical.
+        DataStream<Order> orderStream = env.fromSource(
+            createBoundedSource(1000),
+            noWatermarks(),
+            "Order Data Generator"
+        );
+        tableEnv.createTemporaryView("orders", orderStream);
+        System.out.println("✓ Registered 'orders' table from a bounded order source (1000 orders)\n");
 
-        // Step 3: Demonstrate Kafka Source Table Creation
-        demonstrateKafkaSourceTable();
+        printKafkaTableDdl();
 
-        // Step 4: Show Materialized View Examples
-        showMaterializedViewExamples();
+        // Step 4: Create the materialized views with SQL DDL
+        System.out.println("=== Creating materialized views ===");
 
-        // Step 5: Explain View Querying
-        explainViewQuerying();
-
-        // Step 6: Discuss Continuous Maintenance
-        discussContinuousMaintenance();
-
-        // Step 7: Provide Implementation Roadmap
-        provideImplementationRoadmap();
-
-        System.out.println("\n=== Lesson Complete ===");
-        System.out.println("When Flink 2.0 is released, you can:");
-        System.out.println("1. Uncomment Table API dependencies in build.gradle.kts");
-        System.out.println("2. Replace this conceptual code with actual Table API implementation");
-        System.out.println("3. Run real materialized views with Confluent Cloud");
-        
-        // Note: This is a conceptual lesson - no actual streaming execution needed
-        System.out.println("\nThis conceptual lesson is complete!");
-        System.out.println("Ready to implement with real Confluent Cloud Flink SQL when available.");
-    }
-
-    /**
-     * Explains how to set up Table API environment
-     */
-    private static void explainTableAPISetup() {
-        System.out.println("\n=== Step 2: Table API Environment Setup ===");
-        System.out.println("When Table API dependencies are available, you would:");
-        System.out.println();
-        
-        System.out.println("// Import required classes:");
-        System.out.println("import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;");
-        System.out.println("import org.apache.flink.table.api.Table;");
-        System.out.println();
-        
-        System.out.println("// Create Table Environment:");
-        System.out.println("StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);");
-        System.out.println();
-        
-        System.out.println("Key Benefits:");
-        System.out.println("- Bridges DataStream API and SQL");
-        System.out.println("- Enables SQL queries on streaming data");
-        System.out.println("- Supports complex analytical operations");
-        System.out.println("- Integrates with Confluent Cloud seamlessly");
-    }
-
-    /**
-     * Demonstrates Kafka source table creation
-     */
-    private static void demonstrateKafkaSourceTable() {
-        System.out.println("\n=== Step 3: Kafka Source Table Creation ===");
-        System.out.println("Creating a table from Kafka topic with Confluent Cloud:");
-        System.out.println();
-        
-        String exampleSQL = """
-            CREATE TABLE orders (
-                orderId STRING,
-                customerId STRING,
-                amount DECIMAL(10,2),
-                `timestamp` BIGINT,
-                category STRING,
-                order_time AS TO_TIMESTAMP_LTZ(`timestamp`, 3),
-                WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
-            ) WITH (
-                'connector' = 'kafka',
-                'topic' = 'orders',
-                'properties.bootstrap.servers' = 'your-confluent-cloud-broker',
-                'properties.security.protocol' = 'SASL_SSL',
-                'properties.sasl.mechanism' = 'PLAIN',
-                'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username="<api-key>" password="<api-secret>";',
-                'format' = 'json',
-                'scan.startup.mode' = 'latest-offset'
-            )
-            """;
-        
-        System.out.println("Example DDL:");
-        System.out.println(exampleSQL);
-        
-        System.out.println("Key Features:");
-        System.out.println("- Maps Kafka topic to SQL table");
-        System.out.println("- Supports watermarks for event time");
-        System.out.println("- Handles Confluent Cloud authentication");
-        System.out.println("- Configurable startup modes");
-    }
-
-    /**
-     * Shows examples of materialized views
-     */
-    private static void showMaterializedViewExamples() {
-        System.out.println("\n=== Step 4: Materialized View Examples ===");
-        System.out.println("Individual .flink.sql files have been created in src/main/resources/lesson04/ for each use case:");
-        System.out.println();
-        
-        // Customer Spending Summary
-        System.out.println("1. Customer Spending Summary View (customer-spending-summary.flink.sql):");
-        System.out.println("   Use case: Customer analytics, loyalty programs, personalized marketing");
-        String customerSpendingSQL = """
+        tableEnv.executeSql("""
             CREATE VIEW customer_spending_summary AS
-            SELECT 
+            SELECT
                 customerId,
-                SUM(amount) as total_spent,
-                COUNT(*) as order_count,
-                AVG(amount) as avg_order_value,
-                MAX(amount) as max_order_value,
-                COUNT(DISTINCT category) as categories_purchased
+                SUM(amount)              AS total_spent,
+                COUNT(*)                 AS order_count,
+                AVG(amount)              AS avg_order_value,
+                MAX(amount)              AS max_order_value,
+                COUNT(DISTINCT category) AS categories_purchased
             FROM orders
             GROUP BY customerId
-            """;
-        System.out.println(customerSpendingSQL);
-        
-        // Hourly Sales Metrics
-        System.out.println("2. Hourly Sales Metrics View (hourly-sales-metrics.flink.sql):");
-        System.out.println("   Use case: Real-time dashboards, performance monitoring, trend analysis");
-        String hourlySalesSQL = """
-            CREATE VIEW hourly_sales_metrics AS
-            SELECT 
-                window_start as hour_start,
-                window_end as hour_end,
-                COUNT(*) as total_orders,
-                SUM(amount) as total_revenue,
-                AVG(amount) as avg_order_value,
-                COUNT(DISTINCT customerId) as unique_customers,
-                COUNT(DISTINCT category) as categories_sold,
-                MAX(amount) as max_order_amount,
-                MIN(amount) as min_order_amount
-            FROM TUMBLE(TABLE orders, DESCRIPTOR(order_time), INTERVAL '1' HOUR)
-            GROUP BY window_start, window_end
-            """;
-        System.out.println(hourlySalesSQL);
-        
-        // Customer Segmentation
-        System.out.println("3. Customer Segmentation View (customer-segmentation.flink.sql):");
-        System.out.println("   Use case: Marketing campaigns, customer retention, personalized experiences");
-        String segmentationSQL = """
+            """);
+        System.out.println("✓ customer_spending_summary");
+
+        tableEnv.executeSql("""
             CREATE VIEW customer_segmentation AS
-            SELECT 
+            SELECT
                 customerId,
-                SUM(amount) as total_spent,
-                COUNT(*) as order_count,
-                AVG(amount) as avg_order_value,
-                COUNT(DISTINCT category) as categories_purchased,
-                CASE 
+                SUM(amount)              AS total_spent,
+                COUNT(*)                 AS order_count,
+                AVG(amount)              AS avg_order_value,
+                COUNT(DISTINCT category) AS categories_purchased,
+                CASE
                     WHEN SUM(amount) >= 1000 AND COUNT(*) >= 10 THEN 'VIP'
-                    WHEN SUM(amount) >= 500 OR COUNT(*) >= 5 THEN 'Premium'
-                    WHEN SUM(amount) >= 100 OR COUNT(*) >= 2 THEN 'Regular'
+                    WHEN SUM(amount) >= 500  OR  COUNT(*) >= 5  THEN 'Premium'
+                    WHEN SUM(amount) >= 100  OR  COUNT(*) >= 2  THEN 'Regular'
                     ELSE 'New'
-                END as customer_segment,
+                END AS customer_segment,
                 CASE
                     WHEN COUNT(DISTINCT category) >= 4 THEN 'Diverse'
                     WHEN COUNT(DISTINCT category) >= 2 THEN 'Multi-Category'
                     ELSE 'Single-Category'
-                END as purchase_behavior
+                END AS purchase_behavior
             FROM orders
             GROUP BY customerId
-            """;
-        System.out.println(segmentationSQL);
-        
-        // Reference to additional SQL files
-        System.out.println("4. Category Performance Analysis (category-performance.flink.sql):");
-        System.out.println("   Use case: Inventory management, product strategy, sales optimization");
-        
-        System.out.println("Benefits of Materialized Views:");
-        System.out.println("- Pre-computed results for fast queries");
-        System.out.println("- Automatically updated as data changes");
-        System.out.println("- Support complex aggregations and joins");
-        System.out.println("- Enable real-time analytics dashboards");
-        
-        System.out.println("\n=== Advanced: Materialized Tables with Freshness ===");
-        System.out.println("For production use cases, consider MATERIALIZED TABLE with freshness guarantees:");
-        String materializedTableSQL = """
-            CREATE MATERIALIZED TABLE customer_spending_materialized
-                FRESHNESS = INTERVAL '30' SECOND
-                AS SELECT 
-                    customerId,
-                    SUM(amount) as total_spent,
-                    COUNT(*) as order_count,
-                    AVG(amount) as avg_order_value
-                FROM orders
-                GROUP BY customerId
-            """;
-        System.out.println(materializedTableSQL);
-        System.out.println("Key Benefits of MATERIALIZED TABLE:");
-        System.out.println("- Guaranteed freshness with FRESHNESS parameter");
-        System.out.println("- Automatic refresh based on data changes");
-        System.out.println("- Better performance for frequently accessed data");
-        System.out.println("- Ideal for real-time dashboards and analytics");
+            """);
+        System.out.println("✓ customer_segmentation");
+
+        tableEnv.executeSql("""
+            CREATE VIEW category_performance AS
+            SELECT
+                category,
+                COUNT(*)    AS order_count,
+                SUM(amount) AS total_revenue,
+                AVG(amount) AS avg_order_value
+            FROM orders
+            GROUP BY category
+            """);
+        System.out.println("✓ category_performance\n");
+
+        // Step 5: Query the materialized views. Each print() submits a job and runs it
+        //         to completion against the bounded source; watch them in the Web UI.
+        //         The output is a changelog (+I/-U/+U): you can see each view's aggregates
+        //         being continuously updated as orders are processed — the essence of a
+        //         materialized view. (Streaming SQL doesn't support ORDER BY on a
+        //         non-time attribute, so we print the views unsorted.)
+        System.out.println("=== customer_spending_summary ===");
+        tableEnv.sqlQuery("SELECT * FROM customer_spending_summary").execute().print();
+
+        System.out.println("\n=== customer_segmentation ===");
+        tableEnv.sqlQuery("SELECT * FROM customer_segmentation").execute().print();
+
+        System.out.println("\n=== category_performance ===");
+        tableEnv.sqlQuery("SELECT * FROM category_performance").execute().print();
+
+        System.out.println("\n=== Lesson Complete ===");
+        System.out.println("These views update continuously as new orders arrive — point the");
+        System.out.println("'orders' table at a Kafka topic (see the DDL above) to run them live.");
     }
 
     /**
-     * Explains how to query materialized views
+     * Prints the Kafka source-table DDL that backs these views on Confluent Cloud.
+     * Note the computed {@code order_time} column + watermark: time-windowed views
+     * (hourly-sales-metrics, top-performers-leaderboard) reference {@code order_time}
+     * via {@code TUMBLE(..., DESCRIPTOR(order_time), ...)}.
      */
-    private static void explainViewQuerying() {
-        System.out.println("\n=== Step 5: Querying Materialized Views ===");
-        System.out.println("Once views are created, you can query them like regular tables:");
-        System.out.println();
-        
-        System.out.println("// Query customer spending with Confluent Cloud syntax");
-        System.out.println("Table result = tableEnv.sqlQuery(\"SELECT * FROM customer_spending_summary ORDER BY total_spent DESC LIMIT 10\");");
-        System.out.println("result.execute().print();");
-        System.out.println();
-        
-        System.out.println("// Query recent hourly metrics");
-        System.out.println("Table hourly = tableEnv.sqlQuery(\"SELECT * FROM hourly_sales_metrics ORDER BY hour_start DESC LIMIT 5\");");
-        System.out.println("hourly.execute().print();");
-        System.out.println();
-        
-        System.out.println("// Complex analytical queries with joins");
-        System.out.println("Table analysis = tableEnv.sqlQuery(\"\"\"");
-        System.out.println("    SELECT ");
-        System.out.println("        cs.customer_segment,");
-        System.out.println("        cs.purchase_behavior,");
-        System.out.println("        COUNT(*) as customer_count,");
-        System.out.println("        AVG(cs.total_spent) as avg_spending,");
-        System.out.println("        AVG(cs.categories_purchased) as avg_categories");
-        System.out.println("    FROM customer_segmentation cs");
-        System.out.println("    GROUP BY cs.customer_segment, cs.purchase_behavior");
-        System.out.println("    ORDER BY avg_spending DESC");
-        System.out.println("\"\"\");");
-        System.out.println();
-        
-        System.out.println("// Real-time category performance analysis");
-        System.out.println("Table categoryPerf = tableEnv.sqlQuery(\"\"\"");
-        System.out.println("    SELECT ");
-        System.out.println("        category,");
-        System.out.println("        COUNT(*) as order_count,");
-        System.out.println("        SUM(amount) as total_revenue,");
-        System.out.println("        AVG(amount) as avg_order_value");
-        System.out.println("    FROM orders");
-        System.out.println("    WHERE order_time >= CURRENT_TIMESTAMP - INTERVAL '1' DAY");
-        System.out.println("    GROUP BY category");
-        System.out.println("    ORDER BY total_revenue DESC");
-        System.out.println("\"\"\");");
-        
-        System.out.println("\nConfluent Cloud Query Capabilities:");
-        System.out.println("- Standard SQL syntax with Flink extensions");
-        System.out.println("- Joins between multiple views and tables");
-        System.out.println("- Window functions and time-based analytics");
-        System.out.println("- Real-time continuous queries");
-        System.out.println("- Cross-environment data access");
-        System.out.println("- Built-in functions for stream processing");
-    }
-
-    /**
-     * Discusses continuous view maintenance
-     */
-    private static void discussContinuousMaintenance() {
-        System.out.println("\n=== Step 6: Continuous View Maintenance ===");
-        System.out.println("Confluent Cloud automatically maintains materialized views:");
-        System.out.println();
-        
-        System.out.println("Automatic Updates:");
-        System.out.println("- Views update as new data arrives in Kafka topics");
-        System.out.println("- Incremental computation for efficiency");
-        System.out.println("- Consistent results across all queries");
-        System.out.println("- Built-in fault tolerance and recovery");
-        System.out.println("- Automatic scaling based on workload");
-        System.out.println();
-        
-        System.out.println("Confluent Cloud Benefits:");
-        System.out.println("- Managed infrastructure - no cluster management");
-        System.out.println("- Automatic resource scaling");
-        System.out.println("- Built-in monitoring and alerting");
-        System.out.println("- Cross-region data replication");
-        System.out.println("- Enterprise security and compliance");
-        System.out.println();
-        
-        System.out.println("Performance Optimization:");
-        System.out.println("- Intelligent partitioning strategies");
-        System.out.println("- Optimized state storage");
-        System.out.println("- Query result caching");
-        System.out.println("- Automatic resource allocation");
-        System.out.println("- Real-time performance metrics");
-        System.out.println();
-        
-        System.out.println("Production Best Practices:");
-        System.out.println("- Use appropriate watermark strategies");
-        System.out.println("- Monitor view refresh latency");
-        System.out.println("- Set up proper alerting rules");
-        System.out.println("- Regular performance reviews");
-        System.out.println("- Implement proper access controls");
-    }
-
-    /**
-     * Provides implementation roadmap for when dependencies are available
-     */
-    private static void provideImplementationRoadmap() {
-        System.out.println("\n=== Step 7: Implementation Roadmap ===");
-        System.out.println("Implementation approaches for Confluent Cloud Flink SQL:");
-        System.out.println();
-        
-        System.out.println("Option 1: Confluent Cloud Console (Recommended for Learning)");
-        System.out.println("   - Use browser-based Flink SQL workspace");
-        System.out.println("   - Create tables directly with DDL statements");
-        System.out.println("   - Build and test materialized views interactively");
-        System.out.println("   - Monitor performance in real-time");
-        System.out.println();
-        
-        System.out.println("Option 2: Flink SQL Shell (CLI-based)");
-        System.out.println("   - Use confluent flink shell command");
-        System.out.println("   - Execute SQL statements from command line");
-        System.out.println("   - Suitable for scripted deployments");
-        System.out.println();
-        
-        System.out.println("Option 3: Local Flink 2.0 (When Available)");
-        System.out.println("   - Uncomment Table API dependencies in build.gradle.kts");
-        System.out.println("   - Add flink-table-api-java-bridge:2.0.0");
-        System.out.println("   - Add flink-table-planner:2.0.0");
-        System.out.println("   - Use actual Order schema: orderId, customerId, amount, timestamp, category");
-        System.out.println();
-        
-        System.out.println("Implementation Steps:");
-        System.out.println("   1. Set up Confluent Cloud environment and API keys");
-        System.out.println("   2. Create 'orders' topic with proper schema registry");
-        System.out.println("   3. Use OrderDataGenerator to populate test data");
-        System.out.println("   4. Create source table with correct field mapping:");
-        System.out.println("      - orderId STRING, customerId STRING, amount DECIMAL(10,2)");
-        System.out.println("      - timestamp BIGINT, category STRING");
-        System.out.println("      - Computed column: order_time AS TO_TIMESTAMP_LTZ(timestamp, 3)");
-        System.out.println("   5. Deploy materialized views using provided SQL examples");
-        System.out.println("   6. Test queries and monitor performance");
-        System.out.println();
-        
-        System.out.println("Production Considerations:");
-        System.out.println("   - Use proper RBAC and API key management");
-        System.out.println("   - Configure appropriate compute pools");
-        System.out.println("   - Set up monitoring and alerting");
-        System.out.println("   - Implement proper error handling");
-        System.out.println("   - Document view dependencies and refresh patterns");
+    private static void printKafkaTableDdl() {
+        System.out.println("--- Kafka-backed 'orders' table (Confluent Cloud Flink SQL) ---");
+        System.out.println("""
+            CREATE TABLE orders (
+                orderId     STRING,
+                customerId  STRING,
+                amount      DECIMAL(10,2),
+                `timestamp` BIGINT,
+                category    STRING,
+                order_time  AS TO_TIMESTAMP_LTZ(`timestamp`, 3),
+                WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
+            ) WITH (
+                'connector' = 'kafka',
+                'topic' = 'orders',
+                'properties.bootstrap.servers' = '<broker>',
+                'format' = 'json',
+                'scan.startup.mode' = 'latest-offset'
+            );
+            """);
     }
 }

--- a/src/main/java/com/example/flink/lesson05/CHANGELOG_COLORS.md
+++ b/src/main/java/com/example/flink/lesson05/CHANGELOG_COLORS.md
@@ -1,0 +1,132 @@
+# Changelog Stream Color Coding
+
+This document explains the color scheme used in the ChangelogFormatter for Flink Table API changelog streams.
+
+## Color Scheme Overview
+
+The color scheme follows Flink's changelog semantics and uses intuitive colors to represent different operations:
+
+```
+🟢 Green:  +I (Insert operations)
+🔴 Red:    -D (Delete operations)
+🟡 Yellow: -U (Update before)
+🟠 Orange: +U (Update after)
+🔵 Blue:   Query names/prefixes
+🟣 Purple: Field names
+```
+
+## Detailed Color Mapping
+
+### Operation Types
+
+| Operation | Symbol | Color | Visual | Meaning |
+|-----------|--------|-------|--------|---------|
+| INSERT | +I | 🟢 Bold Green | `[INSERT]` | New record added to the result |
+| UPDATE_BEFORE | -U | 🟡 Yellow | `[UPDATE-]` | Old version before update |
+| UPDATE_AFTER | +U | 🟠 Bold Orange | `[UPDATE+]` | New version after update |
+| DELETE | -D | 🔴 Bold Red | `[DELETE]` | Record removed from result |
+
+### Data Elements
+
+| Element | Color | Purpose |
+|---------|-------|---------|
+| Query Name | 🔵 Bold Blue | Identifies which query produced the result |
+| Field Names | 🟣 Magenta | Distinguishes field names from values |
+| String Values | Green | Text/string data |
+| Numeric Values | Cyan | Numbers (integers, floats, doubles) |
+| Timestamps | Gray | Millisecond timestamps (when enabled) |
+| Null Values | Gray | Missing/null data |
+
+## Example Output
+
+Here's what you'll see in your terminal:
+
+```
+[1762952249603] Customer Spending > [INSERT]    customerId='customer_001', total_spent=450.50, order_count=3
+[1762952249604] Customer Spending > [UPDATE-]  customerId='customer_001', total_spent=450.50, order_count=3
+[1762952249605] Customer Spending > [UPDATE+]  customerId='customer_001', total_spent=650.75, order_count=4
+[1762952249606] Customer Spending > [DELETE]    customerId='customer_001', total_spent=650.75, order_count=4
+```
+
+With actual colors:
+- Gray timestamp `[1762952249603]`
+- Bold blue query name `Customer Spending`
+- Green bold `[INSERT]` or Orange bold `[UPDATE+]`
+- Magenta field names `customerId`, `total_spent`, `order_count`
+- Green strings `'customer_001'`
+- Cyan numbers `450.50`, `3`
+
+## Why These Colors?
+
+### Traffic Light Metaphor
+- 🟢 **Green (INSERT)**: Go! New data flowing in
+- 🟡 **Yellow (UPDATE_BEFORE)**: Caution! Data changing
+- 🟠 **Orange (UPDATE_AFTER)**: Proceed! New value applied
+- 🔴 **Red (DELETE)**: Stop! Data removed
+
+### Semantic Meaning
+- **Green**: Positive action (new data)
+- **Yellow**: Warning (old value being replaced)
+- **Orange**: Transition (new value after change)
+- **Red**: Alert (data removal)
+
+### Visual Hierarchy
+- **Bold colors** (Green, Orange, Red) for operations that change state
+- **Regular yellow** for transient old values
+- **Blue** for context (query name)
+- **Magenta** for structure (field names)
+- **Cyan/Green** for data values
+- **Gray** for metadata (timestamps, nulls)
+
+## Understanding Changelog Streams
+
+When you see output like this:
+
+```
+[UPDATE-]  customerId='customer_001', total_spent=450.50, order_count=3
+[UPDATE+]  customerId='customer_001', total_spent=650.75, order_count=4
+```
+
+It means:
+1. 🟡 The old aggregated value was `total_spent=450.50, order_count=3`
+2. 🟠 The new aggregated value is `total_spent=650.75, order_count=4`
+3. A new order of `200.25` was added for customer_001
+
+## Disabling Colors
+
+If you need plain text output (for logs or non-color terminals):
+
+```java
+// Without colors
+resultStream
+    .map(ChangelogFormatter.detailedNoColor("Query Name"))
+    .print();
+```
+
+## Testing Colors
+
+Run the color demo to see all colors in action:
+
+```bash
+./gradlew runColorDemo
+```
+
+This will display examples of all operation types with their respective colors.
+
+## Terminal Compatibility
+
+Colors work in:
+- ✅ macOS Terminal
+- ✅ iTerm2
+- ✅ Linux terminals (bash, zsh, fish)
+- ✅ Windows Terminal
+- ✅ VS Code integrated terminal
+- ✅ IntelliJ IDEA terminal
+- ✅ Most modern terminal emulators
+
+Colors may not work in:
+- ❌ Very old terminal emulators
+- ❌ Some CI/CD log viewers
+- ❌ Text editors without ANSI support
+
+For these cases, use the `*NoColor` formatter variants.

--- a/src/main/java/com/example/flink/lesson05/utils/README.md
+++ b/src/main/java/com/example/flink/lesson05/utils/README.md
@@ -1,0 +1,118 @@
+# ChangelogFormatter Utility
+
+A utility class for formatting Flink Table API changelog stream output with ANSI colors for better readability.
+
+## Features
+
+- **Color-coded operations**: Different colors for INSERT, UPDATE, and DELETE operations
+- **Field highlighting**: Field names and values are color-coded by type
+- **Timestamp support**: Optional millisecond timestamps for each record
+- **Customizable**: Can disable colors for environments that don't support ANSI codes
+
+## Color Scheme
+
+Following Flink's changelog semantics:
+
+| Element | Color | Emoji | Description |
+|---------|-------|-------|-------------|
+| INSERT (+I) | 🟢 Bold Green | 🟢 | New records added to the stream |
+| UPDATE_BEFORE (-U) | 🟡 Yellow | 🟡 | Old version of a record before update |
+| UPDATE_AFTER (+U) | 🟠 Bold Orange | 🟠 | New version of a record after update |
+| DELETE (-D) | 🔴 Bold Red | 🔴 | Records removed from the stream |
+| Query Prefix | 🔵 Bold Blue | 🔵 | The name of the query (e.g., "Customer Spending") |
+| Field Names | 🟣 Magenta | 🟣 | Names of fields in the record |
+| String Values | Green | | String field values (quoted) |
+| Numeric Values | Cyan | | Integer and floating-point values |
+| Timestamps | Gray | | Millisecond timestamps in brackets |
+| Null Values | Gray | | Null field values |
+
+## Usage Examples
+
+### Basic Usage (with colors and timestamps)
+
+```java
+DataStream<Row> resultStream = tableEnv.toChangelogStream(resultTable);
+resultStream
+    .map(ChangelogFormatter.detailed("Customer Spending"))
+    .print();
+```
+
+### Simple Format (no timestamps, with colors)
+
+```java
+resultStream
+    .map(ChangelogFormatter.simple("Category Performance"))
+    .print();
+```
+
+### Without Colors (for log files)
+
+```java
+resultStream
+    .map(ChangelogFormatter.detailedNoColor("Hourly Sales"))
+    .print();
+```
+
+### Custom Configuration
+
+```java
+resultStream
+    .map(ChangelogFormatter.colored("My Query", true))  // with timestamp
+    .print();
+```
+
+## Example Output
+
+With colors enabled, you'll see output like:
+
+```
+[1762952249603] Customer Spending > [INSERT]    customerId='customer_001', total_spent=450.50, order_count=3
+[1762952249604] Customer Spending > [UPDATE-]  customerId='customer_001', total_spent=450.50, order_count=3
+[1762952249605] Customer Spending > [UPDATE+]  customerId='customer_001', total_spent=650.75, order_count=4
+```
+
+Where:
+- 🟢 Green bold INSERT (+I)
+- 🟡 Yellow UPDATE_BEFORE (-U)
+- 🟠 Orange bold UPDATE_AFTER (+U)
+- 🔴 Red bold DELETE (-D)
+- 🔵 Blue bold query name
+- 🟣 Magenta field names
+- Green strings, Cyan numbers
+- Gray timestamps
+
+## Testing
+
+Run the color demo to see all colors in action:
+
+```bash
+./gradlew runColorDemo
+```
+
+## Implementation Details
+
+The formatter implements `MapFunction<Row, String>` and can be used in any DataStream transformation pipeline. It uses ANSI escape codes for terminal colors, which are supported by most modern terminals including:
+
+- macOS Terminal
+- iTerm2
+- Linux terminals (bash, zsh, etc.)
+- Windows Terminal
+- VS Code integrated terminal
+- IntelliJ IDEA terminal
+
+## Factory Methods
+
+| Method | Timestamps | Colors | Use Case |
+|--------|-----------|--------|----------|
+| `detailed(prefix)` | ✓ | ✓ | Default - full information with colors |
+| `simple(prefix)` | ✗ | ✓ | Cleaner output without timestamps |
+| `detailedNoColor(prefix)` | ✓ | ✗ | Log files or non-color terminals |
+| `simpleNoColor(prefix)` | ✗ | ✗ | Minimal output for logs |
+| `colored(prefix, showTimestamp)` | Custom | ✓ | Full control over settings |
+
+## Notes
+
+- Colors are automatically disabled if the output is redirected to a file
+- The formatter is thread-safe and can be used in parallel streams
+- Numeric values are formatted with 2 decimal places for consistency
+- Field names are extracted from the Row schema when available

--- a/src/main/java/shared/data/generators/KafkaOrderProducer.java
+++ b/src/main/java/shared/data/generators/KafkaOrderProducer.java
@@ -28,7 +28,7 @@ import utils.KafkaUtils;
  *
  * Expected Output:
  * === Kafka Order Producer ===
- * Connecting to Confluent Cloud Kafka...
+ * Connecting to Kafka...
  * ✓ Loaded CFLT_KAFKA_BROKER from environment
  * ✓ Loaded CFLT_KC_API_KEY from environment
  * ✓ Loaded CFLT_KC_API_SECRET from environment
@@ -84,12 +84,14 @@ public class KafkaOrderProducer {
 
     public static void main(String[] args) throws Exception {
         System.out.println("=== Kafka Order Producer ===");
-        System.out.println("Connecting to Confluent Cloud Kafka...");
+        System.out.println("Connecting to Kafka...");
 
-        // Load Confluent Cloud configuration from environment variables
+        // Load Kafka configuration from environment variables.
+        // For local/Docker Kafka, only CFLT_KAFKA_BROKER is needed (PLAINTEXT, no auth);
+        // for Confluent Cloud, also set CFLT_KC_API_KEY / CFLT_KC_API_SECRET.
         String bootstrapServers = KafkaUtils.getEnvVar(
             "CFLT_KAFKA_BROKER",
-            "localhost:49658"
+            "localhost:9092"
         );
         String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
         String apiSecret = KafkaUtils.getEnvVar(

--- a/src/main/java/shared/data/generators/KafkaOrderProducer.java
+++ b/src/main/java/shared/data/generators/KafkaOrderProducer.java
@@ -1,13 +1,11 @@
 package shared.data.generators;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Random;
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-
-import java.util.Random;
-import java.util.concurrent.Future;
-
 import utils.KafkaUtils;
 
 /**
@@ -24,17 +22,16 @@ import utils.KafkaUtils;
  * - Test various customer and product scenarios
  *
  * Prerequisites:
- * - Confluent Cloud account with Kafka cluster
- * - API keys configured in .env file
+ * - Confluent Cloud: API keys configured in .env file (CFLT_KAFKA_BROKER, CFLT_KC_API_KEY, CFLT_KC_API_SECRET)
+ * - Local/Docker: Set CFLT_KAFKA_BROKER=localhost:PORT (no API key/secret needed)
  * - Topic 'orders' created in your Kafka cluster
- * - Environment variables loaded from .env file
  *
  * Expected Output:
  * === Kafka Order Producer ===
  * Connecting to Confluent Cloud Kafka...
- * ✓ Loaded CNFL_KAFKA_BROKER from environment
- * ✓ Loaded CNFL_KC_API_KEY from environment
- * ✓ Loaded CNFL_KC_API_SECRET from environment
+ * ✓ Loaded CFLT_KAFKA_BROKER from environment
+ * ✓ Loaded CFLT_KC_API_KEY from environment
+ * ✓ Loaded CFLT_KC_API_SECRET from environment
  * ✓ Kafka producer configured for Confluent Cloud
  * Starting continuous order generation... Press Ctrl+C to stop.
  * Sent Order> Order{id=order_00001, customer=customer_002, amount=156.78, category=Electronics}
@@ -51,16 +48,38 @@ public class KafkaOrderProducer {
 
     private static final String TOPIC_NAME = "orders";
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    
+
     private final KafkaProducer<String, String> producer;
     private final Random random = new Random();
-    private final String[] customers = {"customer_001", "customer_002", "customer_003", "customer_004", "customer_005"};
-    private final String[] categories = {"Electronics", "Clothing", "Books", "Home", "Sports"};
-    
+    private final String[] customers = {
+        "customer_001",
+        "customer_002",
+        "customer_003",
+        "customer_004",
+        "customer_005",
+    };
+    private final String[] categories = {
+        "Electronics",
+        "Clothing",
+        "Books",
+        "Home",
+        "Sports",
+    };
+
     private volatile boolean running = true;
 
-    public KafkaOrderProducer(String bootstrapServers, String apiKey, String apiSecret) {
-        this.producer = new KafkaProducer<>(KafkaUtils.createProducerKafkaProperties(bootstrapServers, apiKey, apiSecret));
+    public KafkaOrderProducer(
+        String bootstrapServers,
+        String apiKey,
+        String apiSecret
+    ) {
+        this.producer = new KafkaProducer<>(
+            KafkaUtils.createProducerKafkaProperties(
+                bootstrapServers,
+                apiKey,
+                apiSecret
+            )
+        );
     }
 
     public static void main(String[] args) throws Exception {
@@ -68,23 +87,37 @@ public class KafkaOrderProducer {
         System.out.println("Connecting to Confluent Cloud Kafka...");
 
         // Load Confluent Cloud configuration from environment variables
-        String bootstrapServers = KafkaUtils.getEnvVar("CNFL_KAFKA_BROKER", "your-kafka-broker:9092");
-        String apiKey = KafkaUtils.getEnvVar("CNFL_KC_API_KEY", "your-api-key");
-        String apiSecret = KafkaUtils.getEnvVar("CNFL_KC_API_SECRET", "your-api-secret");
+        String bootstrapServers = KafkaUtils.getEnvVar(
+            "CFLT_KAFKA_BROKER",
+            "localhost:49658"
+        );
+        String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
+        String apiSecret = KafkaUtils.getEnvVar(
+            "CFLT_KC_API_SECRET",
+            "your-api-secret"
+        );
 
         System.out.println("Bootstrap servers: " + bootstrapServers);
         System.out.println("Using topic: " + TOPIC_NAME);
 
         // Create and start the producer
-        KafkaOrderProducer orderProducer = new KafkaOrderProducer(bootstrapServers, apiKey, apiSecret);
-        
-        // Add shutdown hook for graceful termination
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println("\nShutting down Kafka Order Producer...");
-            orderProducer.stop();
-        }));
+        KafkaOrderProducer orderProducer = new KafkaOrderProducer(
+            bootstrapServers,
+            apiKey,
+            apiSecret
+        );
 
-        System.out.println("Starting continuous order generation... Press Ctrl+C to stop.");
+        // Add shutdown hook for graceful termination
+        Runtime.getRuntime().addShutdownHook(
+            new Thread(() -> {
+                System.out.println("\nShutting down Kafka Order Producer...");
+                orderProducer.stop();
+            })
+        );
+
+        System.out.println(
+            "Starting continuous order generation... Press Ctrl+C to stop."
+        );
         orderProducer.startProducing();
     }
 
@@ -93,41 +126,51 @@ public class KafkaOrderProducer {
      */
     public void startProducing() throws Exception {
         int orderCounter = 1;
-        
+
         while (running) {
             try {
                 // Generate random order
-                String orderId = "order_" + String.format("%05d", orderCounter++);
+                String orderId =
+                    "order_" + String.format("%05d", orderCounter++);
                 String customerId = customers[random.nextInt(customers.length)];
                 double amount = 10.0 + (random.nextDouble() * 490.0); // $10-$500
                 String category = categories[random.nextInt(categories.length)];
                 long timestamp = System.currentTimeMillis();
-                
-                Order order = new Order(orderId, customerId, amount, timestamp, category);
-                
+
+                Order order = new Order(
+                    orderId,
+                    customerId,
+                    amount,
+                    timestamp,
+                    category
+                );
+
                 // Convert order to JSON
                 String orderJson = objectMapper.writeValueAsString(order);
-                
+
                 // Send to Kafka topic
                 ProducerRecord<String, String> record = new ProducerRecord<>(
-                    TOPIC_NAME, 
+                    TOPIC_NAME,
                     order.customerId, // Use customerId as key for partitioning
                     orderJson
                 );
-                
+
                 Future<RecordMetadata> future = producer.send(record);
-                
+
                 // Educational debugging - show what was sent
                 System.out.println("Sent Order> " + order);
-                
+
                 // Optional: Wait for acknowledgment (educational purposes)
                 RecordMetadata metadata = future.get();
-                System.out.println("  ✓ Delivered to partition " + metadata.partition() + 
-                                 " at offset " + metadata.offset());
-                
+                System.out.println(
+                    "  ✓ Delivered to partition " +
+                        metadata.partition() +
+                        " at offset " +
+                        metadata.offset()
+                );
+
                 // Wait between orders (2-4 seconds for better observation)
                 Thread.sleep(2000 + random.nextInt(2000));
-                
             } catch (Exception e) {
                 System.err.println("Error sending order: " + e.getMessage());
                 e.printStackTrace();
@@ -147,5 +190,4 @@ public class KafkaOrderProducer {
             System.out.println("✓ Kafka producer closed gracefully");
         }
     }
-
 }

--- a/src/main/java/utils/KafkaUtils.java
+++ b/src/main/java/utils/KafkaUtils.java
@@ -1,10 +1,9 @@
 package utils;
 
+import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
-
-import java.util.Properties;
 
 /**
  * Kafka Utilities for Educational Flink Lessons
@@ -21,19 +20,19 @@ import java.util.Properties;
  * - Consistent configuration across all lessons
  *
  * Usage Examples:
- * 
+ *
  * For Kafka Consumers (Flink applications):
  * ```java
- * String apiKey = KafkaUtils.getEnvVar("CNFL_KC_API_KEY", "your-api-key");
- * String apiSecret = KafkaUtils.getEnvVar("CNFL_KC_API_SECRET", "your-api-secret");
+ * String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
+ * String apiSecret = KafkaUtils.getEnvVar("CFLT_KC_API_SECRET", "your-api-secret");
  * Properties props = KafkaUtils.createConsumerKafkaProperties(apiKey, apiSecret);
  * ```
- * 
+ *
  * For Kafka Producers (data generators):
  * ```java
- * String bootstrapServers = KafkaUtils.getEnvVar("CNFL_KAFKA_BROKER", "your-broker:9092");
- * String apiKey = KafkaUtils.getEnvVar("CNFL_KC_API_KEY", "your-api-key");
- * String apiSecret = KafkaUtils.getEnvVar("CNFL_KC_API_SECRET", "your-api-secret");
+ * String bootstrapServers = KafkaUtils.getEnvVar("CFLT_KAFKA_BROKER", "your-broker:9092");
+ * String apiKey = KafkaUtils.getEnvVar("CFLT_KC_API_KEY", "your-api-key");
+ * String apiSecret = KafkaUtils.getEnvVar("CFLT_KC_API_SECRET", "your-api-secret");
  * Properties props = KafkaUtils.createProducerKafkaProperties(bootstrapServers, apiKey, apiSecret);
  * ```
  *
@@ -65,7 +64,12 @@ public class KafkaUtils {
     public static String getEnvVar(String envVarName, String defaultValue) {
         String value = System.getenv(envVarName);
         if (value == null || value.trim().isEmpty()) {
-            System.out.println("⚠️  Environment variable " + envVarName + " not found, using default: " + defaultValue);
+            System.out.println(
+                "⚠️  Environment variable " +
+                    envVarName +
+                    " not found, using default: " +
+                    defaultValue
+            );
             return defaultValue;
         }
         System.out.println("✓ Loaded " + envVarName + " from environment");
@@ -77,7 +81,7 @@ public class KafkaUtils {
      *
      * This method sets up the necessary configuration for Flink Kafka consumers
      * to securely connect to Confluent Cloud using SASL_SSL authentication.
-     * 
+     *
      * Key Configuration Details:
      * - Does NOT set deserializer properties (Flink handles deserialization internally)
      * - Configures SASL_SSL security for Confluent Cloud
@@ -93,30 +97,51 @@ public class KafkaUtils {
      * @param apiSecret Confluent Cloud API secret for authentication
      * @return Properties object configured for Kafka consumer with Confluent Cloud
      */
-    public static Properties createConsumerKafkaProperties(String apiKey, String apiSecret) {
+    public static Properties createConsumerKafkaProperties(
+        String apiKey,
+        String apiSecret
+    ) {
         Properties props = new Properties();
 
         // NOTE: We don't set deserializer properties here because Flink handles
         // deserialization through the deserializer specified in KafkaSource builder
         // Setting deserializers here would conflict with Flink's internal deserialization
 
-        // Confluent Cloud security configuration
-        props.setProperty("security.protocol", "SASL_SSL");
-        props.setProperty("sasl.mechanism", "PLAIN");
-        props.setProperty("sasl.jaas.config", String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required " +
-                "username=\"%s\" password=\"%s\";", apiKey, apiSecret));
+        // Only configure SASL_SSL when real credentials are provided (Confluent Cloud)
+        // For local/Docker Kafka, skip security config entirely (PLAINTEXT is the default)
+        if (isCloudMode(apiKey, apiSecret)) {
+            props.setProperty("security.protocol", "SASL_SSL");
+            props.setProperty("sasl.mechanism", "PLAIN");
+            props.setProperty(
+                "sasl.jaas.config",
+                String.format(
+                    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                        "username=\"%s\" password=\"%s\";",
+                    apiKey,
+                    apiSecret
+                )
+            );
+            System.out.println(
+                "✓ Kafka consumer configured for Confluent Cloud (SASL_SSL)"
+            );
+        } else {
+            System.out.println(
+                "✓ Kafka consumer configured for local Kafka (PLAINTEXT)"
+            );
+        }
 
         // Consumer behavior settings for educational clarity
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        props.setProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+        props.setProperty(
+            ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
+            "1000"
+        );
 
         // Session and heartbeat settings for stable connections
         props.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "30000");
         props.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
 
-        System.out.println("✓ Kafka consumer properties configured for Confluent Cloud");
         return props;
     }
 
@@ -125,7 +150,7 @@ public class KafkaUtils {
      *
      * This method sets up the necessary configuration for Kafka producers
      * to securely connect to Confluent Cloud using SASL_SSL authentication.
-     * 
+     *
      * Key Configuration Details:
      * - Sets bootstrap servers, key/value serializers for producers
      * - Configures SASL_SSL security for Confluent Cloud
@@ -143,20 +168,49 @@ public class KafkaUtils {
      * @param apiSecret       Confluent Cloud API secret for authentication
      * @return Properties object configured for Kafka producer with Confluent Cloud
      */
-    public static Properties createProducerKafkaProperties(String bootstrapServers, String apiKey, String apiSecret) {
+    public static Properties createProducerKafkaProperties(
+        String bootstrapServers,
+        String apiKey,
+        String apiSecret
+    ) {
         Properties props = new Properties();
 
         // Basic producer configuration
-        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.setProperty(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            bootstrapServers
+        );
+        props.setProperty(
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            StringSerializer.class.getName()
+        );
+        props.setProperty(
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            StringSerializer.class.getName()
+        );
 
-        // Confluent Cloud security configuration
-        props.setProperty("security.protocol", "SASL_SSL");
-        props.setProperty("sasl.mechanism", "PLAIN");
-        props.setProperty("sasl.jaas.config", String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required " +
-                "username=\"%s\" password=\"%s\";", apiKey, apiSecret));
+        // Only configure SASL_SSL when real credentials are provided (Confluent Cloud)
+        // For local/Docker Kafka, skip security config entirely (PLAINTEXT is the default)
+        if (isCloudMode(apiKey, apiSecret)) {
+            props.setProperty("security.protocol", "SASL_SSL");
+            props.setProperty("sasl.mechanism", "PLAIN");
+            props.setProperty(
+                "sasl.jaas.config",
+                String.format(
+                    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                        "username=\"%s\" password=\"%s\";",
+                    apiKey,
+                    apiSecret
+                )
+            );
+            System.out.println(
+                "✓ Kafka producer configured for Confluent Cloud (SASL_SSL)"
+            );
+        } else {
+            System.out.println(
+                "✓ Kafka producer configured for local Kafka (PLAINTEXT)"
+            );
+        }
 
         // Producer behavior settings for educational clarity and reliability
         props.setProperty(ProducerConfig.ACKS_CONFIG, "all"); // Wait for all replicas
@@ -168,7 +222,22 @@ public class KafkaUtils {
         props.setProperty(ProducerConfig.LINGER_MS_CONFIG, "10");
         props.setProperty(ProducerConfig.BUFFER_MEMORY_CONFIG, "33554432");
 
-        System.out.println("✓ Kafka producer properties configured for Confluent Cloud");
         return props;
+    }
+
+    /**
+     * Checks if real Confluent Cloud credentials are provided.
+     * Returns false when API key/secret are missing or still at placeholder defaults,
+     * indicating a local/Docker Kafka setup that needs no authentication.
+     */
+    private static boolean isCloudMode(String apiKey, String apiSecret) {
+        return (
+            apiKey != null &&
+            apiSecret != null &&
+            !apiKey.startsWith("your-") &&
+            !apiSecret.startsWith("your-") &&
+            !apiKey.isBlank() &&
+            !apiSecret.isBlank()
+        );
     }
 }

--- a/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
+++ b/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
@@ -8,9 +8,14 @@
 -- - Min/max order amounts for outlier detection
 --
 -- Use case: Real-time dashboards, performance monitoring, trend analysis
+--
+-- Assumes the `orders` table declares a time attribute column, e.g.:
+--   order_time AS TO_TIMESTAMP_LTZ(`timestamp`, 3),
+--   WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
+-- TUMBLE's DESCRIPTOR must reference that column name, not an inline expression.
 
-CREATE TABLE hourly_sales_metrics AS
-SELECT 
+CREATE VIEW hourly_sales_metrics AS
+SELECT
     window_start as hour_start,
     window_end as hour_end,
     COUNT(*) as total_orders,
@@ -20,5 +25,5 @@ SELECT
     COUNT(DISTINCT category) as categories_sold,
     MAX(amount) as max_order_amount,
     MIN(amount) as min_order_amount
-FROM TUMBLE(TABLE orders, DESCRIPTOR(TO_TIMESTAMP_LTZ(`timestamp`, 3)), INTERVAL '1' HOUR)
+FROM TUMBLE(TABLE orders, DESCRIPTOR(order_time), INTERVAL '1' HOUR)
 GROUP BY window_start, window_end;

--- a/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
+++ b/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
@@ -9,10 +9,10 @@
 --
 -- Use case: Real-time dashboards, performance monitoring, trend analysis
 
-CREATE VIEW hourly_sales_metrics AS
+CREATE TABLE hourly_sales_metrics AS
 SELECT 
-    TUMBLE_START(order_time, INTERVAL '1' HOUR) as hour_start,
-    TUMBLE_END(order_time, INTERVAL '1' HOUR) as hour_end,
+    window_start as hour_start,
+    window_end as hour_end,
     COUNT(*) as total_orders,
     SUM(amount) as total_revenue,
     AVG(amount) as avg_order_value,
@@ -20,5 +20,5 @@ SELECT
     COUNT(DISTINCT category) as categories_sold,
     MAX(amount) as max_order_amount,
     MIN(amount) as min_order_amount
-FROM orders
-GROUP BY TUMBLE(order_time, INTERVAL '1' HOUR);
+FROM TUMBLE(TABLE orders, DESCRIPTOR(TO_TIMESTAMP_LTZ(`timestamp`, 3)), INTERVAL '1' HOUR)
+GROUP BY window_start, window_end;

--- a/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
+++ b/src/main/resources/lesson04/hourly-sales-metrics.flink.sql
@@ -25,5 +25,5 @@ SELECT
     COUNT(DISTINCT category) as categories_sold,
     MAX(amount) as max_order_amount,
     MIN(amount) as min_order_amount
-FROM TUMBLE(TABLE orders, DESCRIPTOR(order_time), INTERVAL '1' HOUR)
+FROM TABLE(TUMBLE(TABLE orders, DESCRIPTOR(order_time), INTERVAL '1' HOUR))
 GROUP BY window_start, window_end;

--- a/src/main/resources/lesson04/top-performers-leaderboard.flink.sql
+++ b/src/main/resources/lesson04/top-performers-leaderboard.flink.sql
@@ -1,5 +1,10 @@
 -- Dynamic Top-N Leaderboards: Best Performing Customers & Categories
 -- Real-time ranking with windowed top-N analysis
+--
+-- Assumes the `orders` table declares a time attribute column, e.g.:
+--   order_time AS TO_TIMESTAMP_LTZ(`timestamp`, 3),
+--   WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
+-- TUMBLE's DESCRIPTOR must reference that column name, not an inline expression.
 CREATE VIEW top_performers_leaderboard AS
 SELECT *
 FROM (
@@ -24,8 +29,8 @@ FROM (
         (SUM(amount) * 0.6 + COUNT(*) * 50 * 0.3 + COUNT(DISTINCT category) * 20 * 0.1) as performance_score
     FROM TABLE(
         TUMBLE(
-            TABLE orders, 
-            DESCRIPTOR(TO_TIMESTAMP_LTZ(`timestamp`, 3)), 
+            TABLE orders,
+            DESCRIPTOR(order_time),
             INTERVAL '1' HOUR
         )
     )

--- a/src/main/resources/lesson04/top-performers-leaderboard.flink.sql
+++ b/src/main/resources/lesson04/top-performers-leaderboard.flink.sql
@@ -1,0 +1,34 @@
+-- Dynamic Top-N Leaderboards: Best Performing Customers & Categories
+-- Real-time ranking with windowed top-N analysis
+CREATE VIEW top_performers_leaderboard AS
+SELECT *
+FROM (
+    SELECT 
+        window_start,
+        window_end,
+        customerId,
+        SUM(amount) as total_spent,
+        COUNT(*) as order_count,
+        AVG(amount) as avg_order_value,
+        COUNT(DISTINCT category) as category_diversity,
+        LISTAGG(DISTINCT category, ', ') as categories_purchased,
+        ROW_NUMBER() OVER (
+            PARTITION BY window_start, window_end 
+            ORDER BY SUM(amount) DESC
+        ) as spending_rank,
+        ROW_NUMBER() OVER (
+            PARTITION BY window_start, window_end 
+            ORDER BY COUNT(*) DESC
+        ) as frequency_rank,
+        -- Performance score combining multiple factors
+        (SUM(amount) * 0.6 + COUNT(*) * 50 * 0.3 + COUNT(DISTINCT category) * 20 * 0.1) as performance_score
+    FROM TABLE(
+        TUMBLE(
+            TABLE orders, 
+            DESCRIPTOR(TO_TIMESTAMP_LTZ(`timestamp`, 3)), 
+            INTERVAL '1' HOUR
+        )
+    )
+    GROUP BY window_start, window_end, customerId
+) ranked_customers
+WHERE spending_rank <= 10 OR frequency_rank <= 10;  -- Top 10 in either category

--- a/test-webui.sh
+++ b/test-webui.sh
@@ -101,17 +101,20 @@ echo ""
 tail -f /tmp/flink-lesson01.log &
 TAIL_PID=$!
 
-# Cleanup on exit
+# Cleanup on exit (covers Ctrl+C, termination, AND normal exit when the
+# lesson finishes on its own — otherwise the background `tail -f` leaks).
+_cleaned_up=0
 cleanup() {
+    [ "$_cleaned_up" = "1" ] && return
+    _cleaned_up=1
     echo ""
     echo "Cleaning up..."
     kill $LESSON_PID 2>/dev/null
     kill $TAIL_PID 2>/dev/null
     echo "✅ Cleanup complete"
-    exit 0
 }
 
-trap cleanup INT TERM
+trap cleanup INT TERM EXIT
 
 # Wait for user to stop
 wait $LESSON_PID

--- a/test-webui.sh
+++ b/test-webui.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Test script to verify Flink Web UI is enabled for lessons
+
+echo "========================================="
+echo "Flink Web UI Test Script"
+echo "========================================="
+echo ""
+echo "This script will:"
+echo "1. Build the project"
+echo "2. Start Lesson 1 in the background"
+echo "3. Wait for Web UI to be available"
+echo "4. Test the Web UI endpoint"
+echo "5. Clean up"
+echo ""
+
+# Build the project
+echo "Building project..."
+./gradlew build -x test -q
+if [ $? -ne 0 ]; then
+    echo "❌ Build failed"
+    exit 1
+fi
+echo "✅ Build successful"
+echo ""
+
+# Start Lesson 1 in background
+echo "Starting Lesson 1..."
+./gradlew runLesson01 > /tmp/flink-lesson01.log 2>&1 &
+LESSON_PID=$!
+echo "Started with PID: $LESSON_PID"
+echo ""
+
+# Wait for Web UI to be available (max 30 seconds)
+echo "Waiting for Web UI to be available..."
+MAX_WAIT=30
+COUNTER=0
+while [ $COUNTER -lt $MAX_WAIT ]; do
+    if curl -s http://localhost:8081/config > /dev/null 2>&1; then
+        echo "✅ Web UI is available!"
+        break
+    fi
+    sleep 1
+    COUNTER=$((COUNTER + 1))
+    echo -n "."
+done
+echo ""
+
+if [ $COUNTER -eq $MAX_WAIT ]; then
+    echo "❌ Web UI did not become available within $MAX_WAIT seconds"
+    echo "Check logs at /tmp/flink-lesson01.log"
+    kill $LESSON_PID 2>/dev/null
+    exit 1
+fi
+
+# Test the Web UI
+echo ""
+echo "Testing Web UI endpoints..."
+echo ""
+
+# Test config endpoint
+echo "1. Testing /config endpoint..."
+if curl -s http://localhost:8081/config | grep -q "flink-version"; then
+    echo "   ✅ Config endpoint working"
+else
+    echo "   ❌ Config endpoint failed"
+fi
+
+# Test overview endpoint
+echo "2. Testing /overview endpoint..."
+if curl -s http://localhost:8081/overview | grep -q "taskmanagers"; then
+    echo "   ✅ Overview endpoint working"
+else
+    echo "   ❌ Overview endpoint failed"
+fi
+
+# Test jobs endpoint
+echo "3. Testing /jobs endpoint..."
+if curl -s http://localhost:8081/jobs | grep -q "jobs"; then
+    echo "   ✅ Jobs endpoint working"
+else
+    echo "   ❌ Jobs endpoint failed"
+fi
+
+echo ""
+echo "========================================="
+echo "Test Complete!"
+echo "========================================="
+echo ""
+echo "Web UI is accessible at: http://localhost:8081"
+echo ""
+echo "To view the running job:"
+echo "  1. Open http://localhost:8081 in your browser"
+echo "  2. Click on 'Running Jobs' to see Lesson 1"
+echo "  3. Click on the job to see the execution graph"
+echo ""
+echo "Press Ctrl+C to stop the lesson and close this script"
+echo ""
+
+# Keep the script running and show logs
+tail -f /tmp/flink-lesson01.log &
+TAIL_PID=$!
+
+# Cleanup on exit
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    kill $LESSON_PID 2>/dev/null
+    kill $TAIL_PID 2>/dev/null
+    echo "✅ Cleanup complete"
+    exit 0
+}
+
+trap cleanup INT TERM
+
+# Wait for user to stop
+wait $LESSON_PID


### PR DESCRIPTION
## Summary

Lands previously-uncommitted WIP in four reviewable commits, rebased onto the latest dependency updates (Flink 2.2.0, Gradle 9.5.0).

- **feat(lesson04)**: `MaterializedViewExample` walking through the four materialized-view use cases, plus a new `top-performers-leaderboard.flink.sql` (windowed top-N ranking, renamed from a scratch `my.flink.sql`) and a refined `hourly-sales-metrics.flink.sql`.
- **feat(kafka)**: support local/Docker Kafka. `KafkaUtils.isCloudMode()` applies SASL_SSL only when real credentials are present; local Kafka uses PLAINTEXT with no auth config. Env vars renamed `CNFL_*` → `CFLT_*` (`CFLT_KAFKA_BROKER`, `CFLT_KC_API_KEY`, `CFLT_KC_API_SECRET`) across consumer, producer, and lesson03, with matching doc updates.
- **docs**: project planning docs (`plan.md`, `requirements.md`, `tasks.md`), Web UI guides, migration & Java 21 guides, lesson05 color-output READMEs.
- **chore**: gitignore AI assistant artifacts (`.junie`, `.kiro`, `.claude`) so they stay out of version control.

## Validation

- `./gradlew build shadowJar` is green against Flink **2.2.0** + Gradle **9.5.0**; `flink-demo.jar` builds.
- Clean rebase onto `origin/main` (no conflicts).

## Notes

- ⚠️ **Breaking for existing users**: the `CNFL_*` → `CFLT_*` env-var rename requires updating any local `.env` files.
- No automated tests yet (`test NO-SOURCE`) — a test suite remains the top open item in `docs/tasks.md` (Phase 4).